### PR TITLE
DOP-1115: Add test to verify that database synchronization works

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "extension": ["ts"],
+  "spec": "tests/**.test.ts",
+  "require": "ts-node/register"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "mongodb": "3.6.3"
       },
       "devDependencies": {
+        "@types/mocha": "^8.2.2",
         "@types/mongodb": "^3.6.9",
         "@types/node": "^13.13.4",
         "eslint": "^6.8.0",
         "mocha": "^7.1.2",
+        "ts-node": "^9.1.1",
         "typescript": "^4.2.3"
       }
     },
@@ -55,6 +57,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mocha": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "dev": true
     },
     "node_modules/@types/mongodb": {
       "version": "3.6.9",
@@ -165,6 +173,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -290,14 +304,23 @@
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "node_modules/call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -446,6 +469,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -545,26 +574,33 @@
       "dev": true
     },
     "node_modules/es-abstract": {
-      "version": "1.18.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "dev": true,
       "dependencies": {
+        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.0",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.8.0",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.1",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-abstract/node_modules/object.assign": {
@@ -947,14 +983,17 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -1019,6 +1058,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1029,12 +1077,15 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/he": {
@@ -1218,6 +1269,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1230,6 +1290,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -1240,12 +1315,15 @@
       }
     },
     "node_modules/is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-date-object": {
@@ -1305,16 +1383,44 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "dependencies": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-symbol": {
@@ -1422,6 +1528,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
@@ -2060,6 +2172,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -2115,23 +2246,29 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -2256,6 +2393,41 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -2294,6 +2466,21 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/underscore": {
@@ -2357,6 +2544,22 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {
@@ -2580,6 +2783,15 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
@@ -2617,6 +2829,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/mocha": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "dev": true
     },
     "@types/mongodb": {
       "version": "3.6.9",
@@ -2705,6 +2923,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2812,14 +3036,20 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -2944,6 +3174,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3019,23 +3255,27 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.18.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.0",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.8.0",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.1",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       },
       "dependencies": {
         "object.assign": {
@@ -3338,9 +3578,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -3395,6 +3635,12 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3402,9 +3648,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "he": {
@@ -3553,6 +3799,12 @@
         }
       }
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3562,6 +3814,15 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -3569,9 +3830,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true
     },
     "is-date-object": {
@@ -3613,14 +3874,27 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -3709,6 +3983,12 @@
       "requires": {
         "chalk": "^2.4.2"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "memory-pager": {
       "version": "1.5.0",
@@ -4221,6 +4501,22 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -4274,22 +4570,22 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -4392,6 +4688,28 @@
         "is-number": "^7.0.0"
       }
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4418,6 +4736,18 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
       "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "underscore": {
       "version": "1.2.4",
@@ -4473,6 +4803,19 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {
@@ -4663,6 +5006,12 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "tsc": "tsc",
+    "test": "mocha",
     "search-transport": "node --trace-warnings src/index.js"
   },
   "author": "Andrew Aldridge <andrew.aldridge@mongodb.com>",
@@ -19,10 +20,12 @@
     "mongodb": "3.6.3"
   },
   "devDependencies": {
+    "@types/mocha": "^8.2.2",
     "@types/mongodb": "^3.6.9",
     "@types/node": "^13.13.4",
     "eslint": "^6.8.0",
     "mocha": "^7.1.2",
+    "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   }
 }

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -1,0 +1,322 @@
+import assert from 'assert'
+import crypto from 'crypto'
+import fs from 'fs'
+import util from 'util'
+import S3 from 'aws-sdk/clients/s3'
+import { MongoClient, Collection, TransactionOptions, BulkWriteOperation, Db } from "mongodb"
+// @ts-ignore
+import dive from 'dive'
+// @ts-ignore
+import Logger from 'basic-logger'
+import { Query } from './Query'
+
+const log = new Logger({
+    showTimestamp: true,
+})
+
+interface Document {
+    slug: string
+    title: string
+    headings: string[]
+    text: string
+    preview: string
+    tags: string
+    links: string[]
+}
+
+interface ManifestData {
+    documents: Document[]
+    includeInGlobalSearch: boolean
+    url: string
+    aliases: string[]
+}
+
+interface Manifest {
+    manifest: ManifestData
+    lastModified: Date
+    manifestRevisionId: string
+    searchProperty: string
+}
+
+interface DatabaseDocument extends Document {
+    manifestRevisionId: string
+    searchProperty: string
+    includeInGlobalSearch: boolean
+}
+
+export interface RefreshInfo {
+    deleted: number
+    updated: string[]
+    skipped: string[]
+    errors: Error[]
+    dateStarted: Date
+    dateFinished: Date | null
+    elapsedMS: number | null
+}
+
+function generateHash(data: string): Promise<string> {
+    const hash = crypto.createHash('sha256')
+
+    return new Promise((resolve, reject) => {
+        hash.on('readable', () => {
+            const data = hash.read();
+            if (data) {
+                resolve(data.toString('hex'))
+            }
+        });
+
+        hash.write(data);
+        hash.end();
+    })
+}
+
+export class SearchIndex {
+    currentlyIndexing?: boolean
+    manifestSource: string
+    manifests: Manifest[]
+    errors: Error[]
+
+    client: MongoClient
+    db: Db
+    lastRefresh: RefreshInfo | null
+    documents: Collection
+
+    constructor(manifestSource: string, client: MongoClient) {
+        this.manifestSource = manifestSource
+        this.manifests = []
+        this.errors = []
+
+        this.client = client
+        this.db = client.db('search')
+        this.documents = this.db.collection('documents')
+        this.lastRefresh = null
+    }
+
+    async search(query: Query, searchProperty: string | null) {
+        const aggregationQuery = query.getAggregationQuery(searchProperty)
+        log.info(JSON.stringify(aggregationQuery, null, 4))
+        aggregationQuery.push({$limit: 50})
+        aggregationQuery.push({$project: {
+            "_id": 0,
+            "title": 1,
+            "preview": 1
+        }})
+        const cursor = await this.documents.aggregate(aggregationQuery)
+
+        return await cursor.toArray()
+    }
+
+    async getManifestsFromS3(bucketName: string, prefix: string): Promise<Manifest[]> {
+        const s3 = new S3({apiVersion: '2006-03-01'})
+        const result: S3.Types.ListObjectsV2Output = await util.promisify(s3.makeUnauthenticatedRequest.bind(s3, 'listObjectsV2', {
+            Bucket: bucketName,
+            Prefix: prefix
+        }))()
+
+        if (result.IsTruncated) {
+            // This would indicate something awry, since we shouldn't
+            // ever have more than 1000 properties. And if we ever did,
+            // everything would need to be rearchitected.
+            throw new Error('Got truncated response from S3')
+        }
+
+        const manifests = []
+        for (const bucketEntry of (result.Contents || [])) {
+            if (bucketEntry.Size === 0) {
+                continue
+            }
+
+            assert.ok(bucketEntry.Key)
+
+            const matches = bucketEntry.Key.match(/([^/]+).json$/)
+            if (matches === null) {
+                this.errors.push(new Error(`Got weird filename in manifest listing: "${bucketEntry.Key}"`))
+                continue
+            }
+
+            const searchProperty = matches[1]
+            const data: S3.Types.GetObjectOutput = await util.promisify(s3.makeUnauthenticatedRequest.bind(s3, 'getObject', {
+                Bucket: bucketName,
+                Key: bucketEntry.Key
+            }))()
+
+            assert.ok(data.Body)
+            assert.ok(data.LastModified)
+
+            const body = data.Body.toString('utf-8')
+            const hash = await generateHash(body)
+            const parsed = JSON.parse(body)
+            manifests.push({
+                manifest: parsed,
+                lastModified: data.LastModified,
+                manifestRevisionId: hash,
+                searchProperty: searchProperty
+            })
+        }
+
+        return manifests
+    }
+
+    getManifestsFromDirectory(prefix: string): Promise<Manifest[]> {
+        return new Promise((resolve, reject) => {
+            const manifests: Manifest[] = []
+
+            dive(prefix, async (err: Error | null, path: string, stats: fs.Stats) => {
+                if (err) { reject(err) }
+                const matches = path.match(/([^/]+).json$/)
+                if (!matches) { return }
+                const searchProperty = matches[1]
+                const data = fs.readFileSync(path, {encoding: 'utf-8'})
+                const parsed = JSON.parse(data)
+                const hash = await generateHash(data)
+
+                manifests.push({
+                    manifest: parsed,
+                    lastModified: stats.mtime,
+                    manifestRevisionId: hash,
+                    searchProperty: searchProperty
+                })
+            }, () => {
+                resolve(manifests)
+            })})
+    }
+
+    async getManifests(): Promise<Manifest[]> {
+        const parsedSource = this.manifestSource.match(/((?:bucket)|(?:dir)):(.+)/)
+        if (!parsedSource) {
+            throw new Error('Bad manifest source')
+        }
+
+        let manifests
+        if (parsedSource[1] === 'bucket') {
+            const parts = parsedSource[2].split('/', 2)
+            const bucketName = parts[0].trim()
+            const prefix = parts[1].trim()
+            if (!bucketName.length || !prefix.length) {
+                throw new Error('Bad bucket manifest source')
+            }
+            manifests = await this.getManifestsFromS3(bucketName, prefix)
+        } else if (parsedSource[1] === 'dir') {
+            manifests = await this.getManifestsFromDirectory(parsedSource[2])
+        } else {
+            throw new Error('Unknown manifest source protocol')
+        }
+
+        return manifests
+    }
+
+    async load(): Promise<RefreshInfo> {
+        log.info("Starting fetch")
+        if (this.currentlyIndexing) {
+            throw new Error('already-indexing')
+        }
+        this.currentlyIndexing = true
+
+        let result: RefreshInfo
+        try {
+            const manifests = await this.getManifests()
+            result = await this.sync(manifests)
+        } catch (err) {
+            throw err
+        } finally {
+            this.currentlyIndexing = false
+        }
+
+        this.errors = []
+        log.info(`Finished fetch: ${this.manifests.length} entries`)
+        return result
+    }
+
+    private async sync(manifests: Manifest[]): Promise<RefreshInfo> {
+        // Syncing the database has a few discrete stages:
+        // 1) Fetch all manifests from S3
+        // 2) Upsert all documents
+        // 2.5) Remove documents that should not be part of each manifest
+        // 3) Remove any documents attached to manifests that we don't know about
+
+        const session = this.client.startSession()
+        const transactionOptions: TransactionOptions = {
+            readPreference: 'primary',
+            readConcern: { level: 'local' },
+            writeConcern: { w: 'majority' }
+        };
+
+        const startTime = process.hrtime.bigint()
+        const status: RefreshInfo = {
+            deleted: 0,
+            updated: [],
+            skipped: [],
+            errors: [],
+            dateStarted: new Date(),
+            dateFinished: null,
+            elapsedMS: null
+        }
+
+        try {
+            for (const manifest of this.manifests) {
+                log.info(`Starting transaction: ${manifest.searchProperty}`)
+                assert.strictEqual(typeof manifest.searchProperty, "string")
+                assert.ok(manifest.searchProperty)
+                assert.strictEqual(typeof manifest.manifestRevisionId, "string")
+                assert.ok(manifest.manifestRevisionId)
+
+                await session.withTransaction(async () => {
+                    const operations: BulkWriteOperation<DatabaseDocument>[] = manifest.manifest.documents.map((document) => {
+                        assert.strictEqual(typeof document.slug, "string")
+                        assert.ok(document.slug)
+
+                        const newDocument: DatabaseDocument = {
+                            ...document,
+                            manifestRevisionId: manifest.manifestRevisionId,
+                            searchProperty: manifest.searchProperty,
+                            includeInGlobalSearch: manifest.manifest.includeInGlobalSearch,
+                        }
+
+                        return {
+                            updateOne: {
+                                filter: {searchProperty: newDocument.searchProperty, slug: newDocument.slug},
+                                update: {$set: newDocument},
+                                upsert: true
+                            }
+                        }
+                    })
+
+                    const bulkWriteStatus = await this.documents.bulkWrite(operations, {session, ordered: false})
+                    if (bulkWriteStatus.upsertedCount) {
+                        status.updated.push(manifest.searchProperty)
+                    }
+                }, transactionOptions)
+
+                log.debug(`Removing old documents for ${manifest.searchProperty}`)
+                const deleteResult = await this.documents.deleteMany({
+                    searchProperty: manifest.searchProperty,
+                    manifestRevisionId: {"$ne": manifest.manifestRevisionId}
+                }, {session})
+                status.deleted += (deleteResult.deletedCount === undefined) ? 0 : deleteResult.deletedCount
+                log.debug(`Removed ${deleteResult.deletedCount} documents`)
+            }
+
+            log.debug("Deleting old properties")
+            const deleteResult = await this.documents.deleteMany(
+                {
+                    searchProperty: {
+                        $nin: this.manifests.map(manifest => manifest.searchProperty)
+                    }
+                },
+                {session, w: "majority"})
+            status.deleted += (deleteResult.deletedCount === undefined) ? 0 : deleteResult.deletedCount
+
+            this.lastRefresh = status
+        } catch(err) {
+            log.error(err)
+            status.errors.push(err)
+        } finally {
+            session.endSession()
+            log.info("Done!")
+        }
+
+        status.dateFinished = new Date()
+        status.elapsedMS = Number(process.hrtime.bigint() - startTime) / 1000000
+        return status
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
-import { MongoClient, Collection, TransactionOptions, BulkWriteOperation, Db } from "mongodb"
+import { MongoClient } from "mongodb"
 import assert from 'assert'
 import http from 'http'
 import {parse as parseUrl, UrlWithParsedQuery} from 'url'
@@ -161,9 +161,9 @@ class Marian {
             return
         }
 
-        if (this.index.errors.length > 0) {
+        if (this.index.lastRefresh && this.index.lastRefresh.errors.length > 0) {
             headers['Content-Type'] = 'application/json'
-            const body = JSON.stringify({'errors': this.index.errors})
+            const body = JSON.stringify({'errors': this.index.lastRefresh.errors})
             res.writeHead(200, headers)
             res.end(body)
             return

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,0 +1,84 @@
+import { strictEqual, deepStrictEqual } from "assert"
+import { Db, MongoClient } from "mongodb";
+import { SearchIndex, DatabaseDocument } from "../src/SearchIndex";
+
+const DB = "search_testing"
+
+const PATH_STATE_1 = "dir:tests/test_data/state-1"
+const PATH_STATE_2 = "dir:tests/test_data/state-2"
+
+function sortDocuments(documents: DatabaseDocument[]): void {
+    documents.sort((a, b) => {
+        const aFull = `${a.searchProperty}/${a.slug}`;
+        const bFull = `${b.searchProperty}/${b.slug}`;
+        return (aFull < bFull ? -1 : aFull > bFull ? 1 : 0)
+    })
+}
+
+describe("Synchronization", function() {
+    this.slow(1000)
+    const client = new MongoClient("mongodb://localhost", {useUnifiedTopology: true});
+    let index: SearchIndex
+
+    before(function(done) {
+        client.connect(async (err) => {
+            strictEqual(err, null, `Error connecting to MongoDB: ${err}`)
+            await client.db(DB).dropDatabase()
+            index = new SearchIndex(PATH_STATE_1, client, DB)
+            done()
+        })
+    })
+
+    after(async function() {
+        await client.close()
+    })
+
+    const loadInitialState = async () => {
+        await index.load(PATH_STATE_1)
+        const documentsCursor = client.db(DB).collection("documents")
+        const documents = await documentsCursor.find().toArray()
+        sortDocuments(documents)
+
+        // Ensure that the correct slugs exist for state #1
+        deepStrictEqual(documents.map((doc) => {
+            return `${doc.searchProperty}/${doc.slug}`
+        }), [
+            "bi-connector-v1/index.html",
+            "bi-connector-v2/index.html",
+            "manual/index.html",
+            "manual/tutorial/index.html"
+        ])
+
+        // manual/tutorial/index.html has a typo: ensure that's present
+        strictEqual(
+            documents.filter((doc) => doc.searchProperty == "manual" && doc.slug === "tutorial/index.html")[0].title,
+            "Create a Task Tracker Ap")
+    };
+
+    it("loads initial state", loadInitialState)
+
+    it("loads disjoint state", async function() {
+        await index.load(PATH_STATE_2)
+        const documentsCursor = client.db(DB).collection("documents")
+        const documents = await documentsCursor.find().toArray()
+        sortDocuments(documents)
+
+        // Ensure that the correct slugs exist for state #2
+        deepStrictEqual(documents.map((doc) => {
+            return `${doc.searchProperty}/${doc.slug}`
+        }), [
+            "bi-connector-v2/index.html",
+            "charts/index.html",
+            "manual/index.html",
+            "manual/tutorial/index.html",
+            "manual/tutorial/second-tutorial/index.html"
+        ])
+
+        // manual/tutorial/index.html fixes a typo: ensure the fix is present
+        strictEqual(
+            documents.filter((doc) => doc.searchProperty == "manual" && doc.slug === "tutorial/index.html")[0].title,
+            "Create a Task Tracker App")
+    })
+
+    it("loads initial state", loadInitialState)
+});

--- a/tests/test_data/state-1/bi-connector-v1.json
+++ b/tests/test_data/state-1/bi-connector-v1.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://docs.mongodb.com/bi-connector/v1.0",
+    "includeInGlobalSearch": false,
+    "aliases": [],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB BI Connector v1.0",
+            "headings": [],
+            "text": "BI Connector v1.0",
+            "preview": "",
+            "tags": "",
+            "links": []
+        }
+    ]
+}

--- a/tests/test_data/state-1/bi-connector-v2.json
+++ b/tests/test_data/state-1/bi-connector-v2.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://docs.mongodb.com/bi-connector/v2.0",
+    "includeInGlobalSearch": false,
+    "aliases": ["bi-connector-master"],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB BI Connector v2.0",
+            "headings": [],
+            "text": "BI Connector v2.0",
+            "preview": "",
+            "tags": "",
+            "links": []
+        }
+    ]
+}

--- a/tests/test_data/state-1/manual.json
+++ b/tests/test_data/state-1/manual.json
@@ -1,0 +1,38 @@
+{
+    "url": "https://docs.mongodb.com/manual",
+    "includeInGlobalSearch": true,
+    "aliases": [],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB Realm ",
+            "headings": [
+                "MongoDB Realm ",
+                "Get Started ",
+                "Billing & Reference ",
+                "Stitch Documentation (Legacy) ",
+                "Realm Database Documentation (Legacy) "
+            ],
+            "text": "MongoDB Realm \u00b6 Welcome to the MongoDB Realm documentation!",
+            "preview": "Welcome to the MongoDB Realm documentation!",
+            "tags": "",
+            "links": [
+                "https://docs.mongodb.com/realm/get-started/introduction-web/"
+            ]
+        },
+        {
+            "slug": "tutorial/index.html",
+            "title": "Create a Task Tracker Ap",
+            "headings": [
+                "Create a Task Tracker Ap "
+            ],
+            "text": "Create a Task Tracker App, version 1",
+            "preview": "In this tutorial, you will build a collaborative task tracker app with MongoDB Realm.",
+            "tags": "",
+            "links": [
+                "https://docs.mongodb.com/realm/tutorial/dotnet/",
+                "https://docs.mongodb.com/realm/tutorial/web-graphql/"
+            ]
+        }
+    ]
+}

--- a/tests/test_data/state-2/bi-connector-v2.json
+++ b/tests/test_data/state-2/bi-connector-v2.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://docs.mongodb.com/bi-connector/v2.0",
+    "includeInGlobalSearch": false,
+    "aliases": ["bi-connector-master"],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB BI Connector v2.0",
+            "headings": [],
+            "text": "BI Connector v2.0",
+            "preview": "",
+            "tags": "",
+            "links": []
+        }
+    ]
+}

--- a/tests/test_data/state-2/charts.json
+++ b/tests/test_data/state-2/charts.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://docs.mongodb.com/charts",
+    "includeInGlobalSearch": false,
+    "aliases": [],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB Charts",
+            "headings": [],
+            "text": "Charts",
+            "preview": "",
+            "tags": "",
+            "links": []
+        }
+    ]
+}

--- a/tests/test_data/state-2/manual.json
+++ b/tests/test_data/state-2/manual.json
@@ -1,0 +1,47 @@
+{
+    "url": "https://docs.mongodb.com/manual",
+    "includeInGlobalSearch": true,
+    "aliases": [],
+    "documents": [
+        {
+            "slug": "index.html",
+            "title": "MongoDB Realm ",
+            "headings": [
+                "MongoDB Realm ",
+                "Get Started ",
+                "Billing & Reference ",
+                "Stitch Documentation (Legacy) ",
+                "Realm Database Documentation (Legacy) "
+            ],
+            "text": "MongoDB Realm \u00b6 Welcome to the MongoDB Realm documentation!",
+            "preview": "Welcome to the MongoDB Realm documentation!",
+            "tags": "",
+            "links": [
+                "https://docs.mongodb.com/realm/get-started/introduction-web/"
+            ]
+        },
+        {
+            "slug": "tutorial/index.html",
+            "title": "Create a Task Tracker App",
+            "headings": [
+                "Create a Task Tracker App "
+            ],
+            "text": "Create a Task Tracker App, version 2",
+            "preview": "In this tutorial, you will build a collaborative task tracker app with MongoDB Realm.",
+            "tags": "",
+            "links": [
+                "https://docs.mongodb.com/realm/tutorial/dotnet/",
+                "https://docs.mongodb.com/realm/tutorial/web-graphql/"
+            ]
+        },
+        {
+            "slug": "tutorial/second-tutorial/index.html",
+            "title": "Create a Second Task Tracker App",
+            "headings": [],
+            "text": "Create a Second Task Tracker App",
+            "preview": "In this tutorial, you will build a new collaborative task tracker app with MongoDB Realm.",
+            "tags": "",
+            "links": []
+        }
+    ]
+}


### PR DESCRIPTION
This also includes a refactor to make testing easier, mainly moving `SearchIndex` to its own file.

The test contains two states, and tests transitioning the database from state 1 to state 2, and back to state 1 again. Tested mutations:
* Added properties (state 2 contains `charts.json`)
* Added documents (state 2 contains `tutorial/second-tutorial/index.html`)
* Removed properties (state 1->2 removes `bi-connector-v1`)
* Removed documents (state 2->1 removes `tutorial/second-tutorial/index.html`)
* Mutated documents (state 1->2 fixes a typo in `manual.json`: `s/Ap/App`)