### PR TITLE
Don't throw when handling a bad origin in checkAllowedOrigin()

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -112,6 +112,16 @@ describe('http interface', function () {
       },
     });
     strictEqual(result.response.headers['access-control-allow-origin'], 'https://docs.mongodb.com');
+
+    // Test an unparseable origin URL
+    result = await request({
+      port: ctx.port,
+      path: `/status`,
+      headers: {
+        Origin: 'gooblygoobly',
+      },
+    });
+    strictEqual(result.response.headers['access-control-allow-origin'], undefined);
   });
 
   after('shutting down', function () {


### PR DESCRIPTION
Also removes deprecated node API.