### PR TITLE
Add searchProperty to projection

### DIFF
--- a/build/SearchIndex.js
+++ b/build/SearchIndex.js
@@ -158,6 +158,7 @@ class SearchIndex {
         title: 1,
         preview: 1,
         url: 1,
+        searchProperty: 1,
       },
     });
     const cursor = await this.documents.aggregate(aggregationQuery);

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -225,6 +225,7 @@ export class SearchIndex {
         title: 1,
         preview: 1,
         url: 1,
+        searchProperty: 1,
       },
     });
     const cursor = await this.documents.aggregate(aggregationQuery);


### PR DESCRIPTION
This adds the searchProperty field to the projection shown from docs-search-transport.