### PR TITLE
DOP-3032: adding synonyms to search queries

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -244,6 +244,7 @@ export class Query {
       text: {
         query: terms,
         path: 'text',
+        synonyms: 'search_synonyms',
       },
     });
 
@@ -252,6 +253,7 @@ export class Query {
         query: terms,
         path: 'headings',
         score: { boost: { value: 5 } },
+        synonyms: 'search_synonyms',
       },
     });
 
@@ -259,6 +261,7 @@ export class Query {
       text: {
         query: terms,
         path: 'title',
+        synonyms: 'search_synonyms',
         score: { boost: { value: 10 } },
       },
     });
@@ -267,6 +270,7 @@ export class Query {
       text: {
         query: terms,
         path: 'tags',
+        synonyms: 'search_synonyms',
         score: { boost: { value: 10 } },
       },
     });


### PR DESCRIPTION
**DO NOT MERGE** until we're confident that this won't break everything.

Per the docs, we need to add a 'synonyms' field to the `$search` agg pipeline stage if you wish to use synonyms in your searching. This should do that.

search_synonyms is currently configured in `search-staging.documents`, my intention is to copy that over to prod once we test this, assuming it's possible to test this only in staging. For what it's worth, if you include the synonyms bit in the query and you've not configured synonyms, you get an angry error:

```
MongoServerError: Remote error from mongot :: caused by :: unknown synonym mapping name "search_synonyms"
```