### PR TITLE
DOP-3368: restore support for legacy-style manifests

### DIFF
--- a/build/Query.js
+++ b/build/Query.js
@@ -220,7 +220,7 @@ class Query {
     parts.push({
       text: {
         query: terms,
-        path: ['paragraphs', 'code.lang'],
+        path: ['paragraphs', 'code.lang', 'code.value', 'text'],
       },
     });
     parts.push({
@@ -228,13 +228,6 @@ class Query {
         query: terms,
         path: 'headings',
         score: { boost: { value: 5 } },
-      },
-    });
-    parts.push({
-      text: {
-        query: terms,
-        path: 'code.value',
-        score: { boost: { value: 10 } },
       },
     });
     parts.push({
@@ -264,7 +257,7 @@ class Query {
         return {
           phrase: {
             query: phrase,
-            path: ['paragraphs', 'headings', 'code.value', 'title'],
+            path: ['paragraphs', 'text', 'headings', 'code.value', 'title'],
           },
         };
       });

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -243,7 +243,7 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: ['paragraphs', 'code.lang'],
+        path: ['paragraphs', 'code.lang', 'code.value', 'text'],
       },
     });
 
@@ -252,14 +252,6 @@ export class Query {
         query: terms,
         path: 'headings',
         score: { boost: { value: 5 } },
-      },
-    });
-
-    parts.push({
-      text: {
-        query: terms,
-        path: 'code.value',
-        score: { boost: { value: 10 } },
       },
     });
 
@@ -294,7 +286,7 @@ export class Query {
         return {
           phrase: {
             query: phrase,
-            path: ['paragraphs', 'headings', 'code.value', 'title'],
+            path: ['paragraphs', 'text', 'headings', 'code.value', 'title'],
           },
         };
       });

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -18,8 +18,9 @@ export interface Document {
   slug: string;
   title?: string;
   headings?: string[];
-  paragraphs: string;
-  code: {}[];
+  text?: string; // legacy manifests have text instead of paragraphs
+  paragraphs?: string; // legacy manifests will not have paragraphs
+  code?: {}[]; // legacy manifests will not have code field
   preview?: string;
   tags: null | string[];
 }


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/browse/DOP-3368) Properties that still build with the legacy tooling use mut-0.9.x to generate their search manifests (from the built HTML rather than from the parser-generated AST). Since we would still like non-Snooty-deployed sites to be included in search, this PR restores the `text` field in query construction in docs-search-transport and makes the `code` and `paragraphs` fields optional 