### PR TITLE
DOP-3441-Staging: Updated Kanopy memory limits and upgraded helm-chart 4.7.3 to 4.12.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ steps:
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
-      chart_version: 4.7.3
+      chart_version: 4.12.0
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
       release: docs-search-transport

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -27,6 +27,6 @@ probes:
 
 resources:
   limits:
-    memory: 350Mi
+    memory: 550Mi
   requests:
-    memory: 500Mi
+    memory: 400Mi


### PR DESCRIPTION
Ticket: DOP-3441

### Notes

Updated Kanopy memory limits and requests to a more accurate allowance.

Kanopy team has decreed that all helm-chart apps must upgrade to at least v4.12.0 because of a breaking change going forward with k8 1.22 API deprecations. Slack message can [be found here](https://mongodb.slack.com/archives/CCKCR28BH/p1660591811877929).

Breaking this into two PRs to ensure safety of prod api