### PR TITLE
DOP-3441-prod: Upgraded chart versions to 4.12.3, memory limits and requests for prod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ steps:
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
-      chart_version: 4.12.0
+      chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
       release: docs-search-transport
@@ -65,7 +65,7 @@ steps:
     image: quay.io/mongodb/drone-helm:v3
     settings:
       chart: mongodb/web-app
-      chart_version: 4.7.3
+      chart_version: 4.12.3
       add_repos: [mongodb=https://10gen.github.io/helm-charts]
       namespace: docs
       release: docs-search-transport

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -26,6 +26,6 @@ probes:
 
 resources:
   limits:
-    memory: 900Mi
+    memory: 1300Mi
   requests:
-    memory: 1200Mi
+    memory: 1100Mi


### PR DESCRIPTION
Ticket: [DOP-3441](https://jira.mongodb.org/browse/DOP-3441)

### Notes

Updated memory limits and requests before Kanopy team sets mandatory amounts. Decided to go higher for safety's sake and further investigation of Kanopy's grafana charts over the past six months.

Upgraded `helm-chart` version of prod primarily. However, also upgraded staging to the latest version after speaking with Staff Infra Engineer. This upgrade is necessary for newer releases to follow [k8's 1.22 API scheduled deprecation](https://mongodb.slack.com/archives/CCKCR28BH/p1660591811877929).

Before merging but after approval, I will use the `mapkubeapis` Helm plugin to update deprecated and removed API versions in-place which is required for a successful build with the new `helm-chart` upgrade. The steps and reasonings can be seen [here](https://github.com/10gen/kanopy-docs/blob/master/docs/advisories/2023-01-04_deprecated_APIs.md#post-upgrade-remediation-steps).

Upgrade of staging env went smoothly and as planned yesterday. 
