### PR TITLE
DOP-3458: Add query analytics field

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -296,8 +296,8 @@ export class Query {
       {
         $search: {
           compound,
-          tracking : {
-            searchTerms : this.terms, 
+          tracking: {
+            searchTerms: this.terms,
           },
         },
       },

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -296,6 +296,9 @@ export class Query {
       {
         $search: {
           compound,
+          tracking : {
+            searchTerms : this.terms, 
+          },
         },
       },
       { $match: filter },


### PR DESCRIPTION
DOP-3458

Adds a `tracking` field to enable query analytics.


![image](https://user-images.githubusercontent.com/3813528/220388702-5403aef8-9636-4f08-b9cf-8c1faa5d8b9a.png)
