### PR TITLE
DOP-3585: allocate memory for node process. default back to 512 after fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm ci --production && chown -R node:node /app
 USER node
 
 EXPOSE 8080
-ENTRYPOINT ["node", "build/index.js"]
+ENTRYPOINT ["node", "--max-old-space-size=4096", "build/index.js"]

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -27,6 +27,6 @@ probes:
 
 resources:
   limits:
-    memory: 550Mi
+    memory: 5120Mi
   requests:
     memory: 400Mi


### PR DESCRIPTION
Increase [node process memory allocation ](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) to avoid error in ticket.

will follow up with a ticket to identify the area of memory leak and revert this fix