### PR TITLE
DOP-3585: allow empty slug when composing upserts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm ci --production && chown -R node:node /app
 USER node
 
 EXPOSE 8080
-ENTRYPOINT ["node", "--max-old-space-size=4096", "build/index.js"]
+ENTRYPOINT ["node", "build/index.js"]

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -27,6 +27,6 @@ probes:
 
 resources:
   limits:
-    memory: 5120Mi
+    memory: 550Mi
   requests:
     memory: 400Mi

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -376,7 +376,9 @@ const deleteStaleProperties = async (
 const composeUpserts = (manifest: Manifest, documents: Document[]): AnyBulkWriteOperation<DatabaseDocument>[] => {
   return documents.map((document) => {
     assert.strictEqual(typeof document.slug, 'string');
-    assert.ok(document.slug);
+    // DOP-3545 and DOP-3585
+    // slug is possible to be empty string ''
+    assert.ok(document.slug || document.slug === '');
 
     const newDocument: DatabaseDocument = {
       ...document,


### PR DESCRIPTION
Allow empty string value for slug, based on DOP-3545
- reverts [previous fix](https://github.com/mongodb/docs-search-transport/pull/31) for increasing memory allocation for node process
- based on [this error](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1679578304.2371746&offset=0&latest_time=) for 

```
[2023-03-23 08:01:11] (error) AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
assert_1.default.ok(document.slug)
at /app/build/SearchIndex.js:284:22
```