### PR TITLE
DOP-3585: commit build file

### DIFF
--- a/build/SearchIndex.js
+++ b/build/SearchIndex.js
@@ -281,7 +281,9 @@ const deleteStaleProperties = async (collection, manifests, session, status) => 
 const composeUpserts = (manifest, documents) => {
   return documents.map((document) => {
     assert_1.default.strictEqual(typeof document.slug, 'string');
-    assert_1.default.ok(document.slug);
+    // DOP-3545 and DOP-3585
+    // slug is possible to be empty string ''
+    assert_1.default.ok(document.slug || document.slug === '');
     const newDocument = {
       ...document,
       url: joinUrl(manifest.manifest.url, document.slug),


### PR DESCRIPTION
[latest logs](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1679597830.2420111&offset=49&latest_time=) were showing that [this change](https://github.com/mongodb/docs-search-transport/pull/32) didn't propogate. resultant of build files not being updated. ran `npx prettier --write .` after tsc as per node scripts