### PR TITLE
Fix build step: include force flag for removing build dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src/index.js"
   ],
   "scripts": {
-    "build": "rm -r build; tsc && npm run format",
+    "build": "rm -rf build; tsc && npm run format",
     "test": "mocha",
     "lint": "npx prettier --check . && tsc --noEmit",
     "format": "npx prettier --write .",


### PR DESCRIPTION
from drone build logs: https://drone.corp.mongodb.com/mongodb/docs-search-transport/75/1/2

```
Step 8/14 : RUN npm run build
 ---> Running in 37844b994578

> search-transport@0.1.0 build /app
> rm -r build; tsc && npm run format

rm: can't remove 'build': No such file or directory
sh: tsc: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! search-transport@0.1.0 build: `rm -r build; tsc && npm run format`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the search-transport@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2023-04-10T21_30_02_066Z-debug.log
The command '/bin/sh -c npm run build' returned a non-zero code: 1
exit status 1
time="2023-04-10T21:30:02Z" level=fatal msg="exit status 1"
```

tested locally with rm -rf flag, removes silently it `/build` directory does not exist