### PR TITLE
DOP-3596: include tsc as part of prod dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,5 @@
 
 !package.json
 !package-lock.json
-!build/**/*.js
 !tsconfig.json
+!src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:14-alpine
 RUN mkdir -p /app
 WORKDIR /app
-COPY . /app
+COPY package.json /app
+COPY package-lock.json* /app
+RUN npm install
 
 ENV NODE_ENV=production
-RUN npm ci --production && chown -R node:node /app
+RUN chown -R node:node /app
 USER node
 
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM node:14-alpine
-RUN mkdir -p /app
+# build stage
+FROM node:14-alpine as builder
 WORKDIR /app
-COPY package.json /app
-COPY package-lock.json* /app
-RUN npm install
 
-ENV NODE_ENV=production
-RUN chown -R node:node /app
-USER node
-
+COPY package*.json tsconfig*.json ./
+RUN npm ci
+COPY . ./
 RUN npm run build
+
+# main image
+FROM node:14-alpine as main
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+COPY --from=builder /app/build ./build
+
 EXPOSE 8080
 ENTRYPOINT ["node", "build/index.js"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "basic-logger": "^0.4.4",
     "dive": "^0.5.0",
     "dotenv": "^16.0.3",
-    "mongodb": "^5.1.0"
+    "mongodb": "^5.1.0",
+    "typescript": "^4.2.3"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.2",
@@ -37,7 +38,6 @@
     "lint-staged": "^11.0.0",
     "mocha": "^7.1.2",
     "prettier": "2.3.0",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.2.3"
+    "ts-node": "^9.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src/index.js"
   ],
   "scripts": {
-    "build": "rm -rf build; tsc && npm run format",
+    "build": "rm -rf ./build/ && tsc",
     "test": "mocha",
     "lint": "npx prettier --check . && tsc --noEmit",
     "format": "npx prettier --write .",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "basic-logger": "^0.4.4",
     "dive": "^0.5.0",
     "dotenv": "^16.0.3",
-    "mongodb": "^5.1.0",
-    "typescript": "^4.2.3"
+    "mongodb": "^5.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.2",
@@ -38,6 +37,7 @@
     "lint-staged": "^11.0.0",
     "mocha": "^7.1.2",
     "prettier": "2.3.0",
-    "ts-node": "^9.1.1"
+    "ts-node": "^9.1.1",
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
from this build log:

https://drone.corp.mongodb.com/mongodb/docs-search-transport/76/1/2

```
> search-transport@0.1.0 build /app
> rm -rf build; tsc && npm run format

sh: tsc: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! search-transport@0.1.0 build: `rm -rf build; tsc && npm run format`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the search-transport@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

since we install with npm ci --production