### PR TITLE
DOP-3603

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3603'
 
 steps:
   - name: publish-staging

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -258,6 +258,14 @@ export class Query {
     parts.push({
       text: {
         query: terms,
+        path: { "value": "headings", "multi": "whitespace" },
+        score: { boost: { value: 20 } },
+      },
+    });
+
+    parts.push({
+      text: {
+        query: terms,
         path: 'title',
         score: { boost: { value: 10 } },
       },

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -258,7 +258,7 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: { "value": "headings", "multi": "whitespace" },
+        path: { "value": "headings", "multi": "custom.whitespace" },
         score: { boost: { value: 5 } },
       },
     });
@@ -274,7 +274,7 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: { "value": "title", "multi": "whitespace" },
+        path: { "value": "title", "multi": "custom.whitespace" },
         score: { boost: { value: 10 } },
       },
     });

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -258,7 +258,7 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: { "value": "headings", "multi": "custom.whitespace" },
+        path: { "value": "headings", "multi": "whitespace" },
         score: { boost: { value: 5 } },
       },
     });
@@ -274,7 +274,7 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: { "value": "title", "multi": "custom.whitespace" },
+        path: { "value": "title", "multi": "whitespace" },
         score: { boost: { value: 10 } },
       },
     });

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -259,7 +259,7 @@ export class Query {
       text: {
         query: terms,
         path: { "value": "headings", "multi": "whitespace" },
-        score: { boost: { value: 20 } },
+        score: { boost: { value: 5 } },
       },
     });
 
@@ -267,6 +267,14 @@ export class Query {
       text: {
         query: terms,
         path: 'title',
+        score: { boost: { value: 10 } },
+      },
+    });
+
+    parts.push({
+      text: {
+        query: terms,
+        path: { "value": "title", "multi": "whitespace" },
         score: { boost: { value: 10 } },
       },
     });


### PR DESCRIPTION
This PR specifically allows users to search for terms using $<phrase> searches, for example $and $or.

**Prereq:** Search Index must be updated for the following

Currently in prod, these are existing field mappings:

```
      "headings": {
        "analyzer": "lucene.english",
        "searchAnalyzer": "lucene.english",
        "store": false,
        "type": "string"
      }
...
      "title": {
        "analyzer": "lucene.english",
        "searchAnalyzer": "lucene.english",
        "store": false,
        "type": "string"
      }
```

where `lucene.english` will [strip out punctuation](https://lucene.apache.org/core/3_0_3/api/all/org/apache/lucene/analysis/standard/StandardTokenizer.html) and [use stop words](https://lucene.apache.org/core/7_5_0/core/org/apache/lucene/analysis/standard/StandardAnalyzer.html) to prevent queries as above.

The custom analyzer below separates strings by whitespace, and filters out strings that do not start with a `$`
The following additions should be updated (already done in search-staging.default search index):
```
{
  "mappings": {
    "dynamic": false,
    "fields": {
      ...
      "headings": {
        "analyzer": "lucene.english",
        "multi": {
          "whitespace": {
            "analyzer": "custom.whitespace",
            "store": false,
            "type": "string"
          }
        },
        "searchAnalyzer": "lucene.english",
        "store": false,
        "type": "string"
      },
      ...,
     "title": {
        "analyzer": "lucene.english",
        "multi": {
          "whitespace": {
            "analyzer": "custom.whitespace",
            "store": false,
            "type": "string"
          }
        },
        "searchAnalyzer": "lucene.english",
        "store": false,
        "type": "string"
      },
    }
  },
  "analyzers": [
    {
      "charFilters": [],
      "name": "custom.whitespace",
      "tokenFilters": [
        {
          "matches": "all",
          "pattern": "^(?!$)\\w+",
          "replacement": "",
          "type": "regex"
        }
      ],
      "tokenizer": {
        "type": "whitespace"
      }
    }
  ]
...
}
```

This allows the query changes below to search across different paths of multi analyzers

**Test results:** 
https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=$and
https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=$or

