### PR TITLE
update tests based on changes to search index server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ATLAS_URI: ${{ secrets.CI_ATLAS_URI }}
+      GROUP_ID: ${{ env.GROUP_ID }}
+      ATLAS_ADMIN_API_KEY: ${{ secrets.ATLAS_ADMIN_API_KEY }}
+      ATLAS_ADMIN_PUB_KEY: ${{ secrets.ATLAS_ADMIN_PUB_KEY }}
     strategy:
       matrix:
         node-version: [14.x]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ATLAS_URI: ${{ secrets.CI_ATLAS_URI }}
-      GROUP_ID: ${{ env.GROUP_ID }}
+      GROUP_ID: ${{ vars.GROUP_ID }}
       ATLAS_ADMIN_API_KEY: ${{ secrets.ATLAS_ADMIN_API_KEY }}
       ATLAS_ADMIN_PUB_KEY: ${{ secrets.ATLAS_ADMIN_PUB_KEY }}
     strategy:

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from 'assert';
 import { Query } from '../../src/Query';
-import { SearchIndex } from '../../src/SearchIndex';
+import { SearchIndex, Taxonomy } from '../../src/SearchIndex';
 import { MongoClient } from 'mongodb';
 
 const TEST_DATABASE = 'search-test';
@@ -19,7 +19,7 @@ describe('Searching', function () {
   before('Loading test data', async function () {
     await client.connect();
     index = new SearchIndex('dir:tests/integration/search_test_data/', client, TEST_DATABASE);
-    const result = await index.load();
+    const result = await index.load({} as Taxonomy);
     await index.createRecommendedIndexes();
 
     // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -7,7 +7,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 export function startServer(path: string, done: () => void): { child: child_process.ChildProcess; port: number } {
-  let isDone = false;
+  let isDone = false, isLoaded = false;
   const child = child_process.spawn('./node_modules/.bin/ts-node', ['./src/index.ts'], {
     stdio: [0, 'pipe', 2],
     env: {
@@ -15,6 +15,11 @@ export function startServer(path: string, done: () => void): { child: child_proc
       ATLAS_DATABASE: 'search-test',
       ATLAS_URI: process.env.ATLAS_URI,
       PATH: process.env.PATH,
+      GROUP_ID: process.env.GROUP_ID,
+      CLUSTER_NAME: process.env.CLUSTER_NAME,
+      COLLECTION_NAME: process.env.COLLECTION_NAME,
+      ATLAS_ADMIN_API_KEY: process.env.ATLAS_ADMIN_API_KEY,
+      ATLAS_ADMIN_PUB_KEY: process.env.ATLAS_ADMIN_PUB_KEY
     },
   });
 
@@ -30,20 +35,23 @@ export function startServer(path: string, done: () => void): { child: child_proc
   };
 
   rl.on('line', (line: string): void => {
-    if (isDone) {
-      return;
-    }
 
     const match = line.match(/Listening on port ([0-9]+)/);
+
     if (match) {
+      isLoaded = true;
       ctx.port = parseInt(match[1]);
     }
 
     if (line.match(/Done!$/)) {
       isDone = true;
-      done();
     } else if (line.match(/Error/)) {
       throw new Error(line);
+    }
+
+    if (isDone && isLoaded) {
+      done();
+      return;
     }
   });
 
@@ -89,7 +97,7 @@ describe('http interface', function () {
 
   let ctx: { child: child_process.ChildProcess; port: number } | null = null;
 
-  before('starting server', function (done) {
+  before('starting server', function (done) {    
     ctx = startServer('dir:tests/manifests/', done);
   });
 
@@ -129,6 +137,6 @@ describe('http interface', function () {
 
   after('shutting down', function () {
     ok(ctx);
-    process.kill(ctx.child.pid, 'SIGINT');
+    process.kill(ctx.child.pid!, 'SIGINT');
   });
 });

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -7,7 +7,8 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 export function startServer(path: string, done: () => void): { child: child_process.ChildProcess; port: number } {
-  let isDone = false, isLoaded = false;
+  let isDone = false,
+    isLoaded = false;
   const child = child_process.spawn('./node_modules/.bin/ts-node', ['./src/index.ts'], {
     stdio: [0, 'pipe', 2],
     env: {
@@ -19,7 +20,7 @@ export function startServer(path: string, done: () => void): { child: child_proc
       CLUSTER_NAME: process.env.CLUSTER_NAME,
       COLLECTION_NAME: process.env.COLLECTION_NAME,
       ATLAS_ADMIN_API_KEY: process.env.ATLAS_ADMIN_API_KEY,
-      ATLAS_ADMIN_PUB_KEY: process.env.ATLAS_ADMIN_PUB_KEY
+      ATLAS_ADMIN_PUB_KEY: process.env.ATLAS_ADMIN_PUB_KEY,
     },
   });
 
@@ -35,7 +36,6 @@ export function startServer(path: string, done: () => void): { child: child_proc
   };
 
   rl.on('line', (line: string): void => {
-
     const match = line.match(/Listening on port ([0-9]+)/);
 
     if (match) {
@@ -97,7 +97,7 @@ describe('http interface', function () {
 
   let ctx: { child: child_process.ChildProcess; port: number } | null = null;
 
-  before('starting server', function (done) {    
+  before('starting server', function (done) {
     ctx = startServer('dir:tests/manifests/', done);
   });
 

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual, deepStrictEqual } from 'assert';
 import { Db, MongoClient } from 'mongodb';
-import { SearchIndex, DatabaseDocument } from '../../src/SearchIndex';
+import { SearchIndex, DatabaseDocument, Taxonomy } from '../../src/SearchIndex';
 
 const DB = 'search-test';
 
@@ -32,7 +32,7 @@ describe('Synchronization', function () {
   });
 
   const loadInitialState = async () => {
-    await index.load(PATH_STATE_1);
+    await index.load({} as Taxonomy, PATH_STATE_1);
     const documentsCursor = client.db(DB).collection<DatabaseDocument>('documents');
     const documents = await documentsCursor.find().toArray();
     sortDocuments(documents);
@@ -54,7 +54,7 @@ describe('Synchronization', function () {
   it('loads initial state', loadInitialState);
 
   it('loads disjoint state', async function () {
-    await index.load(PATH_STATE_2);
+    await index.load({} as Taxonomy, PATH_STATE_2);
     const documentsCursor = client.db(DB).collection<DatabaseDocument>('documents');
     const documents = await documentsCursor.find().toArray();
     sortDocuments(documents);


### PR DESCRIPTION
Two changes broke the unit tests:
- search transport server now instantiates after loading in the manifests (as well as search index update)
- search index requires a `Taxonomy` object when loading (required for query parsing)