### PR TITLE
DOP-3779: return 400 on single letter queries

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3779'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3779'
 
 steps:
   - name: publish-staging

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -1,7 +1,8 @@
 'use strict';
 
-import { InvalidQuery } from '.';
 import { Taxonomy } from './SearchIndex';
+
+export class InvalidQuery extends Error {}
 
 const CORRELATIONS = [
   ['regexp', 'regex', 0.8],

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { InvalidQuery } from '.';
 import { Taxonomy } from './SearchIndex';
 
 const CORRELATIONS = [
@@ -229,6 +230,9 @@ export class Query {
         const phraseParts = processPart(phrase);
         this.addTerms(phraseParts);
       }
+    }
+    if (!this.terms.size) {
+      throw new InvalidQuery();
     }
   }
 

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -240,7 +240,7 @@ export class SearchIndex {
         searchProperty: 1,
       },
     });
-    const cursor = await this.documents.aggregate(aggregationQuery);
+    const cursor = this.documents.aggregate(aggregationQuery);
     return await cursor.toArray();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ function checkMethod(req: http.IncomingMessage, res: http.ServerResponse, method
   return true;
 }
 
-class InvalidQuery extends Error {}
+export class InvalidQuery extends Error {}
 
 class Marian {
   index: SearchIndex;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,13 @@ dotenv.config();
 import { Document, MongoClient } from 'mongodb';
 import assert from 'assert';
 import http from 'http';
-import fetch from 'node-fetch';
 import { parse } from 'toml';
 
 // @ts-ignore
 import Logger from 'basic-logger';
 
 import { taxonomy } from './data/sample-taxonomy';
-import { Query } from './Query';
+import { Query, InvalidQuery } from './Query';
 import { isPermittedOrigin } from './util';
 import { SearchIndex, RefreshInfo, Taxonomy } from './SearchIndex';
 import { AtlasAdminManager } from './AtlasAdmin';
@@ -76,8 +75,6 @@ function checkMethod(req: http.IncomingMessage, res: http.ServerResponse, method
 
   return true;
 }
-
-export class InvalidQuery extends Error {}
 
 class Marian {
   index: SearchIndex;


### PR DESCRIPTION
Minor fix to not timeout on single letter queries.

[stage request responds with 400 but empty results ](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=a)
[prod request hangs with no response](https://docs-search-transport.mongodb.com/search?q=a)