### PR TITLE
Environment fix: use different pub key for prod

### DIFF
--- a/environments/all.yml
+++ b/environments/all.yml
@@ -6,7 +6,6 @@ env:
   GROUP_ID: '5bad1d3d96e82129f16c5df3'
   CLUSTER_NAME: 'Search'
   COLLECTION_NAME: 'documents'
-  ATLAS_ADMIN_PUB_KEY: 'dgrhrxpv'
 
 service:
   targetPort: 8080

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -6,6 +6,7 @@ ingress:
 env:
   MANIFEST_URI: 's3://docs-search-indexes-test/search-indexes/prd/'
   ATLAS_DATABASE: 'search'
+  ATLAS_ADMIN_PUB_KEY: 'cbkapemu'
 
 resources:
   limits:

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -6,6 +6,7 @@ ingress:
 env:
   MANIFEST_URI: 's3://docs-search-indexes-test/search-indexes/preprd/'
   ATLAS_DATABASE: 'search-staging'
+  ATLAS_ADMIN_PUB_KEY: 'dgrhrxpv'
 
 resources:
   limits:


### PR DESCRIPTION
We're actually using two different public/private keys for staging and prod users for Atlas Admin API
We were reference the same public key for both env