### PR TITLE
DOP-3869

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3869'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3869'
 
 steps:
   - name: publish-staging

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=builder /app/build ./build
 COPY --from=builder /app/resources ./resources
 
 EXPOSE 8080
-ENTRYPOINT ["node", "build/index.js"]
+ENTRYPOINT ["node", "build/index.js", "--load-manifests"]

--- a/src/SearchIndex.ts
+++ b/src/SearchIndex.ts
@@ -199,6 +199,7 @@ function getManifestsFromDirectory(prefix: string): Promise<Manifest[]> {
 /// dir:<path> to load manifests from a local directory.
 /// s3://<bucketName>/<prefix> to load manifests from an S3 location.
 async function getManifests(manifestSource: string): Promise<Manifest[]> {
+  log.info(`Loading manifests from ${manifestSource}`);
   const parsed = new URL(manifestSource);
 
   let manifests;
@@ -281,9 +282,13 @@ export class SearchIndex {
     }
   }
 
-  async load(taxonomy: Taxonomy, manifestSource?: string): Promise<RefreshInfo> {
+  async load(taxonomy: Taxonomy, manifestSource?: string, refreshManifests = true): Promise<RefreshInfo | undefined> {
     this.taxonomy = taxonomy;
     this.convertedTaxonomy = convertTaxonomyResponse(taxonomy);
+
+    if (!refreshManifests) {
+      return;
+    }
 
     log.info('Starting fetch');
     if (this.currentlyIndexing) {

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -23,7 +23,7 @@ describe('Searching', function () {
     await index.createRecommendedIndexes();
 
     // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃
-    if (result.deleted || result.updated.length > 0) {
+    if (result && (result.deleted || result.updated.length > 0)) {
       this.timeout(8000);
       await new Promise((resolve) => setTimeout(resolve, 5000));
     }

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -10,7 +10,7 @@ dotenv.config();
 export function startServer(path: string, done: () => void): { child: child_process.ChildProcess; port: number } {
   let isDone = false,
     isLoaded = false;
-  const child = child_process.spawn('./node_modules/.bin/ts-node', ['./src/index.ts'], {
+  const child = child_process.spawn('./node_modules/.bin/ts-node', ['./src/index.ts', '--load-manifests'], {
     stdio: [0, 'pipe', 2],
     env: {
       MANIFEST_URI: 'dir:tests/integration/search_test_data/',


### PR DESCRIPTION
[DOP-3932](https://jira.mongodb.org/browse/DOP-3932)

Enables server to be started without having to refresh manifests, for dev productivity.

Tested on stage for deployments to be started the same as previous behavior, refreshing manifests on load. [Log](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1691605708.3420720&offset=132&latest_time=) from [deployment](https://drone.corp.mongodb.com/mongodb/docs-search-transport/152)