### PR TITLE
DOP-3950: Add emptychar stopword to $ analyzer

### DIFF
--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -101,6 +101,10 @@ export const SearchIndex: IndexMappings = {
           replacement: '',
           type: 'regex',
         },
+        {
+          "type": "stopword",
+          "tokens": [""]
+        }
       ],
       tokenizer: {
         type: 'whitespace',

--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -103,8 +103,8 @@ export const SearchIndex: IndexMappings = {
         },
         {
           "type": "stopword",
-          "tokens": [""]
-        }
+          "tokens": [""],
+        },
       ],
       tokenizer: {
         type: 'whitespace',

--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -102,8 +102,8 @@ export const SearchIndex: IndexMappings = {
           type: 'regex',
         },
         {
-          "type": "stopword",
-          "tokens": [""],
+          type: 'stopword',
+          tokens: [''],
         },
       ],
       tokenizer: {


### PR DESCRIPTION
### Context

https://jira.mongodb.org/browse/DOP-3950

This change adds `''` as a stopword to prevent the custom whitespace analyzer being used for `$` prefixed cases from querying for empty strings.

