### PR TITLE
Update synonym analyzer

### DIFF
--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -87,7 +87,7 @@ export const SearchIndex: IndexMappings = {
       source: {
         collection: SYNONYM_COLLECTION_NAME,
       },
-      analyzer: 'lucene.keyword',
+      analyzer: 'lucene.english',
     },
   ],
   analyzers: [


### PR DESCRIPTION
Hello!

Charles Burnett, our Atlas Search SA, told me our synonym file isn't working because the synonym analyzer needs to match index/query analyzers.  Previously our synonym analyzer was lucene.keyword, but we're using lucene.english for our query & index analyzers.  They both need to be lucene.english for the synonym file to take effect.  I've made that change with this pull request, which should solve the problem.

Thank you!
Sarah