### PR TITLE
DOP-3978

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3978'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3787'
+      - 'refs/heads/DOP-3978'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -105,11 +105,12 @@ export default class Marian {
     } catch (err) {
       if (err instanceof InvalidQuery) {
         res.writeHead(400, headers);
-        res.end('[]');
+        res.end(err.message);
         return;
       }
-
-      throw err;
+      res.writeHead(500, headers);
+      res.end();
+      return;
     }
     let responseBody = JSON.stringify({ results: results });
     res.writeHead(200, headers);
@@ -246,7 +247,7 @@ export default class Marian {
     }
 
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    return await this.index.search(query, searchProperty, pageNumber);
+    return this.index.search(query, searchProperty, pageNumber);
   }
 
   private async fetchTaxonomy(url: string) {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -115,17 +115,20 @@ export class Query {
     const compound: { should: any[]; must: any[]; filter?: any[]; minimumShouldMatch: number } = {
       should: parts,
       minimumShouldMatch: 1,
-      must: [{
-        equals: {
-          path: 'includeInGlobalSearch',
-          value: true
-        }
-      }, {
-        phrase: {
-          path: 'searchProperty',
-          query: Object.keys(searchPropertyMapping)
-        }
-      }]
+      must: [
+        {
+          equals: {
+            path: 'includeInGlobalSearch',
+            value: true,
+          },
+        },
+        {
+          phrase: {
+            path: 'searchProperty',
+            query: Object.keys(searchPropertyMapping),
+          },
+        },
+      ],
     };
 
     // if there are any phrases in quotes
@@ -168,10 +171,12 @@ export class Query {
   getAggregationQuery(searchProperty: string[] | null, page?: number): any[] {
     const compound = this.getCompound();
     if (searchProperty !== null && searchProperty.length !== 0) {
-      compound.must.push({phrase: {
-        path: 'searchProperty',
-        query: searchProperty
-      }});
+      compound.must.push({
+        phrase: {
+          path: 'searchProperty',
+          query: searchProperty,
+        },
+      });
     }
 
     const agg: Filter<Document>[] = [
@@ -182,7 +187,7 @@ export class Query {
             searchTerms: this.rawQuery,
           },
         },
-      }
+      },
     ];
 
     const RES_COUNT = 50;

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -122,14 +122,18 @@ export class Query {
             value: true,
           },
         },
-        {
-          phrase: {
-            path: 'searchProperty',
-            query: Object.keys(searchPropertyMapping),
-          },
-        },
       ],
     };
+    const searchPropertyNames = Object.keys(searchPropertyMapping);
+
+    if (searchPropertyNames?.length) {
+      compound.must.push({
+        phrase: {
+          path: 'searchProperty',
+          query: searchPropertyNames,
+        },
+      });
+    }
 
     // if there are any phrases in quotes
     if (this.phrases.length > 0) {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -173,6 +173,9 @@ export class Query {
   }
 
   getAggregationQuery(searchProperty: string[] | null, page?: number): any[] {
+    if (page && page < 1) {
+      throw new InvalidQuery('Invalid page');
+    }
     const compound = this.getCompound();
     if (searchProperty !== null && searchProperty.length !== 0) {
       compound.must.push({

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -39,24 +39,7 @@ export class SearchIndex {
   }
 
   async search(query: Query, searchProperty: string[] | null, pageNumber?: number) {
-    const aggregationQuery = query.getAggregationQuery(searchProperty);
-    const RES_COUNT = 50;
-    const PAGINATED_RES_COUNT = 10;
-    aggregationQuery.push({
-      $project: {
-        _id: 0,
-        title: 1,
-        preview: 1,
-        url: 1,
-        searchProperty: 1,
-      },
-    });
-    if (!pageNumber) {
-      aggregationQuery.push({ $limit: RES_COUNT });
-    } else {
-      aggregationQuery.push({ $skip: PAGINATED_RES_COUNT * (pageNumber - 1) });
-      aggregationQuery.push({ $limit: PAGINATED_RES_COUNT });
-    }
+    const aggregationQuery = query.getAggregationQuery(searchProperty, pageNumber);
     const cursor = this.documents.aggregate(aggregationQuery);
     return await cursor.toArray();
   }

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -41,7 +41,7 @@ export class SearchIndex {
   async search(query: Query, searchProperty: string[] | null, pageNumber?: number) {
     const aggregationQuery = query.getAggregationQuery(searchProperty, pageNumber);
     const cursor = this.documents.aggregate(aggregationQuery);
-    return await cursor.toArray();
+    return cursor.toArray();
   }
 
   async fetchFacets(query: Query) {

--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -79,6 +79,12 @@ export const SearchIndex: IndexMappings = {
         store: false,
         type: 'string',
       },
+      searchProperty: {
+        type: 'string'
+      },
+      includeInGlobalSearch: {
+        type: 'boolean'
+      }
     },
   },
   synonyms: [

--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -80,11 +80,11 @@ export const SearchIndex: IndexMappings = {
         type: 'string',
       },
       searchProperty: {
-        type: 'string'
+        type: 'string',
       },
       includeInGlobalSearch: {
-        type: 'boolean'
-      }
+        type: 'boolean',
+      },
     },
   },
   synonyms: [

--- a/tests/integration/search_test_data/manual-v5.1.json
+++ b/tests/integration/search_test_data/manual-v5.1.json
@@ -1,6 +1,6 @@
 {
     "url": "https://docs.mongodb.com//v5.1",
-    "includeInGlobalSearch": false,
+    "includeInGlobalSearch": true,
     "documents": [
         {
             "slug": "index.html",


### PR DESCRIPTION
**Context:**

Currently, we are getting mismatches on [meta searches](https://docs-search-transport.mongodb.com/v2/search/meta?q=potato) and [search results](https://docs-search-transport.mongodb.com/search?q=potato). The count should match up exactly with the total count of the search results.

**Problem:**
The issue lied with that we were not filtering the $searchMeta query with 
1) search manifest fields defined in DOP-3787 which filters on `document.searchProperty`
2) were not filtering for `includeInGlobalSearch = true`

**Solution:**
Since
1) $searchMeta can only be run as the first step in an aggregation and matching is not possible thereafter, and 
2) $match is [slow performant](https://www.mongodb.com/docs/atlas/atlas-search/performance/query-performance/#-match-aggregation-stage-usage) after a $search stage

Indexed fields `searchProperty` (string) and `includeInGlobalSearch` (boolean) and included them in `compound` operator of both `$search` and `$searchMeta`

[Stage search results shows 1](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=potato)
[Stage search meta results 1](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=potato)

[Stage search results show 668 (67 pages * 10 + 8 res on last page)](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=test&page=67)
[Stage search meta results shows 668 count](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=test)

[Stage search works with searchProperty included](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=test&searchProperty=manual-v6.0)
