### PR TITLE
DOP-3961

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3961'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3961'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -290,8 +290,13 @@ export default class Marian {
     const filters = extractFacetFilters(parsedUrl.searchParams);
     const query = new Query(rawQuery, filters);
 
+    let searchProperty = parsedUrl.searchParams.getAll('searchProperty') || null;
+    if (typeof searchProperty === 'string') {
+      searchProperty = [searchProperty];
+    }
+
     try {
-      return this.index.fetchFacets(query);
+      return this.index.fetchFacets(query, searchProperty);
     } catch (e) {
       console.error(`Error fetching facet metadata: ${JSON.stringify(e)}`);
       throw e;

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -79,10 +79,6 @@ export default class Marian {
       if (checkMethod(req, res, 'GET')) {
         this.handleStatusV2(req, res);
       }
-    } else if (pathname === '/v2/status') {
-      if (checkMethod(req, res, 'GET')) {
-        this.handleStatusV2(req, res);
-      }
     } else {
       res.writeHead(400, {});
       res.end('');

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -126,8 +126,17 @@ export class Query {
     };
     const searchPropertyNames = Object.keys(searchPropertyMapping);
 
-    // must match all searchPropertyNames indexed by server
-    if (searchPropertyNames?.length) {
+    // if user requested searchProperty, must match this property name
+    // TODO: change to filters.
+    if (searchProperty !== null && searchProperty.length !== 0) {
+      compound.must.push({
+        phrase: {
+          path: 'searchProperty',
+          query: searchProperty,
+        },
+      });
+    } else if (searchPropertyNames?.length) {
+      // must match all searchPropertyNames indexed by server otherwise
       compound.must.push({
         phrase: {
           path: 'searchProperty',
@@ -148,17 +157,6 @@ export class Query {
           };
         })
       );
-    }
-
-    // if user requested searchProperty, must match this property name
-    // TODO: change to filters.
-    if (searchProperty !== null && searchProperty.length !== 0) {
-      compound.must.push({
-        phrase: {
-          path: 'searchProperty',
-          query: searchProperty,
-        },
-      });
     }
 
     return compound;

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -44,8 +44,8 @@ export class SearchIndex {
     return cursor.toArray();
   }
 
-  async fetchFacets(query: Query) {
-    const metaAggregationQuery = query.getMetaQuery(this.convertedTaxonomy);
+  async fetchFacets(query: Query, searchProperty: string[] | null) {
+    const metaAggregationQuery = query.getMetaQuery(searchProperty, this.convertedTaxonomy);
     const cursor = this.documents.aggregate(metaAggregationQuery);
     try {
       const aggRes = await cursor.toArray();


### PR DESCRIPTION
In order to show correct total count from /v2/meta query, we have to *temporarily* use searchProperty in the aggregation queries the same way /search does, until we use facets on front end.

Test route: 
https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=test&searchProperty=atlas-master

now this matches the total count with paginated results (10th page, 9 results = 99 total count)
https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=test&searchProperty=atlas-master&page=10

Previous query for $searchMeta
```
            "must": [
              { "equals": { "path": "includeInGlobalSearch", "value": true } },
              {
                "phrase": {
                  "path": "searchProperty",
                  "query": [ LIST OF ALL SEARCH PROPERTIES ]
                }
              }
            ]
```

New query for $searchMeta (see last must clause for added searchProperty):

```
            "must": [
              { "equals": { "path": "includeInGlobalSearch", "value": true } },
              {
                "phrase": {
                  "path": "searchProperty",
                  "query": [ LIST OF ALL SEARCH PROPERTIES ]
                }
              },
              {
                "phrase": {
                  "path": "searchProperty",
                  "query": ["atlas-master"]
                }
              }
            ]
```