### PR TITLE
DOP-4048

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4048-responsive'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-4048'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4048'
+      - 'refs/heads/DOP-4048-responsive'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -4,7 +4,6 @@ import Logger from 'basic-logger';
 import http from 'http';
 import { parse } from 'toml';
 
-import { taxonomy } from '../data/sample-taxonomy';
 import { checkAllowedOrigin, checkMethod } from './util';
 import { StatusResponse } from './types';
 import { SearchIndex } from '../SearchIndex';

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -267,7 +267,7 @@ export default class Marian {
     };
     Object.assign(headers, STANDARD_HEADERS);
     checkAllowedOrigin(req.headers.origin, headers);
-    const responseBody = JSON.stringify(this.index.convertedTaxonomy);
+    const responseBody = JSON.stringify(this.index.responseFacets);
     res.writeHead(200, headers);
     res.end(responseBody);
   }

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -132,7 +132,7 @@ export class Query {
     const searchPropertyNames = Object.keys(searchPropertyMapping);
 
     // if user requested searchProperty, must match this property name
-    // TODO: change to filters.
+    // allowing mix usage of searchProperty and facets
     if (searchProperty !== null && searchProperty.length !== 0) {
       compound.must.push({
         phrase: {
@@ -173,9 +173,19 @@ export class Query {
       );
     }
 
+    for (const key in this.filters) {
+      compound.must.push({
+        phrase: {
+          query: this.filters[key],
+          path: key
+        }
+      });
+    }
+
     return compound;
   }
 
+  // TODO: update this to work with new facet children structure
   getMetaQuery(searchProperty: string[] | null, taxonomyTrie: FacetDisplayNames) {
     const compound = this.getCompound(searchProperty);
 

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
-import { getFacetsForMeta, tokenize } from './util';
-import { Document, FacetDisplayNames } from '../SearchIndex/types';
+import { getFacetAggregationStages, tokenize } from './util';
+import { Document, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
 
@@ -177,19 +177,22 @@ export class Query {
       compound.must.push({
         phrase: {
           query: this.filters[key],
-          path: key
-        }
+          path: key,
+        },
       });
     }
 
     return compound;
   }
 
-  // TODO: update this to work with new facet children structure
-  getMetaQuery(searchProperty: string[] | null, taxonomyTrie: FacetDisplayNames) {
+  // TODO: update this to work with new facet structure (children and options)
+  // should expand all of taxonomy into document.facets keys (ie. search index keys)
+  // then return aggregation pipeline stages[]
+  // ie. target_product>atlas>versions
+  getMetaQuery(searchProperty: string[] | null, taxonomy: FacetOption[]) {
     const compound = this.getCompound(searchProperty);
 
-    const facets = getFacetsForMeta(this.filters, taxonomyTrie);
+    const facets = getFacetAggregationStages(taxonomy);
 
     const agg = [
       {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 import { getFacetAggregationStages, tokenize } from './util';
-import { Document, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
+import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
 

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 
-import { Document, FacetAggregationStage, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
+import { Document, FacetAggregationStage, FacetOption } from '../SearchIndex/types';
 
 const atomicPhraseMap: Record<string, string> = {
   ops: 'manager',
@@ -80,14 +80,23 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return filter;
 };
 
-// TODO: update this to work with new facet structure (children and options)
 export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
   const facetKeysForAgg: FacetAggregationStage = {};
 
-  // TODO: traverse all of taxonomy to get facets for meta
-  for (const facetOption of taxonomy) {
-    console.log(facetOption);
+  function getKeysFromFacetOptions(facetOptions: FacetOption[]) {
+    for (const facetOption of facetOptions) {
+      facetKeysForAgg[facetOption.key] = {
+        type: 'string',
+        path: `facets.${facetOption.key}`,
+      };
+      for (const facetValue of facetOption.options) {
+        if (facetValue.facets?.length) {
+          getKeysFromFacetOptions(facetValue.facets);
+        }
+      }
+    }
   }
 
+  getKeysFromFacetOptions(taxonomy);
   return facetKeysForAgg;
 };

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 
-import { Document, FacetDisplayNames } from '../SearchIndex/types';
+import { Document, FacetAggregationStage, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
 
 const atomicPhraseMap: Record<string, string> = {
   ops: 'manager',
@@ -80,47 +80,14 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return filter;
 };
 
-// TODO: update this to use with new children attribute taxonomy
-export const getFacetsForMeta = (filter: Filter<Document>, taxonomy: FacetDisplayNames) => {
-  const facets: { [key: string]: { type: 'string'; path: string } } = {};
+// TODO: update this to work with new facet structure (children and options)
+export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
+  const facetKeysForAgg: FacetAggregationStage = {};
 
-  for (const baseFacet in taxonomy) {
-    facets[baseFacet] = {
-      type: 'string',
-      path: `facets.${baseFacet}`,
-    };
+  // TODO: traverse all of taxonomy to get facets for meta
+  for (const facetOption of taxonomy) {
+    console.log(facetOption);
   }
 
-  for (const [key, values] of Object.entries(filter)) {
-    const facetKey = key.replace('facets.', '');
-    for (const value of values) {
-      const entry = _lookup(taxonomy, facetKey, value);
-      if (typeof entry === 'object') {
-        for (const entryKey in entry) {
-          if (['name', 'displayName'].indexOf(entryKey) > -1) {
-            continue;
-          }
-          facets[`${facetKey}>${value}>${entryKey}`] = {
-            type: 'string',
-            path: `${key}>${value}>${entryKey}`,
-          };
-        }
-      }
-    }
-  }
-
-  return facets;
-};
-
-const _lookup = (taxonomy: FacetDisplayNames, facetKey: string, value: string) => {
-  let ref: { [key: string]: any } = taxonomy;
-
-  const parts = facetKey.split('>');
-  for (let idx = 0; idx < parts.length; idx++) {
-    const part = parts[idx];
-    if (ref[part]) {
-      ref = ref[part];
-    }
-  }
-  return ref[value];
+  return facetKeysForAgg;
 };

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -80,6 +80,7 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return filter;
 };
 
+// TODO: update this to use with new children attribute taxonomy
 export const getFacetsForMeta = (filter: Filter<Document>, taxonomy: FacetDisplayNames) => {
   const facets: { [key: string]: { type: 'string'; path: string } } = {};
 

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -5,7 +5,7 @@ import { MongoClient, Collection, TransactionOptions, AnyBulkWriteOperation, Db,
 
 import { convertTaxonomyResponse, formatFacetMetaResponse, getManifests, joinUrl } from './util';
 import { Query } from '../Query';
-import { Document, Manifest, DatabaseDocument, RefreshInfo, Taxonomy, FacetDisplayNames, FacetAggRes } from './types';
+import { Document, Manifest, DatabaseDocument, RefreshInfo, Taxonomy, FacetOption, FacetAggRes } from './types';
 
 const log = new Logger({
   showTimestamp: true,
@@ -22,7 +22,7 @@ export class SearchIndex {
   documents: Collection<DatabaseDocument>;
   unindexable: Collection<DatabaseDocument>;
   taxonomy: Taxonomy;
-  convertedTaxonomy: FacetDisplayNames;
+  convertedTaxonomy: FacetOption[];
 
   constructor(manifestSource: string, client: MongoClient, databaseName: string) {
     this.currentlyIndexing = false;
@@ -35,7 +35,7 @@ export class SearchIndex {
     this.unindexable = this.db.collection<DatabaseDocument>('unindexable');
     this.lastRefresh = null;
     this.taxonomy = {};
-    this.convertedTaxonomy = {};
+    this.convertedTaxonomy = [];
   }
 
   async search(query: Query, searchProperty: string[] | null, pageNumber?: number) {
@@ -48,9 +48,13 @@ export class SearchIndex {
     const metaAggregationQuery = query.getMetaQuery(searchProperty, this.convertedTaxonomy);
     const cursor = this.documents.aggregate(metaAggregationQuery);
     try {
-      const aggRes = await cursor.toArray();
-      const res = formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.convertedTaxonomy);
-      return res;
+      // TODO: re-implement
+      // const aggRes = await cursor.toArray();
+      // const res = formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.convertedTaxonomy);
+      return {
+        count: 0,
+        aggRes: null,
+      };
     } catch (e) {
       log.error(`Error while fetching facets: ${JSON.stringify(e)}`);
       throw e;

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -53,9 +53,9 @@ export interface TaxonomyEntity {
 export type Taxonomy = Record<string, TaxonomyEntity[]>;
 
 // Facets
-export type FacetDisplayNames = {
-  name?: string;
-  [key: string]: FacetDisplayNames | string | boolean | undefined;
+export type TrieFacet = {
+  name: string;
+  [key: string]: TrieFacet | string | boolean | undefined;
 };
 
 export type FacetBucket = {
@@ -76,20 +76,20 @@ export type FacetAggRes = {
 };
 
 export type FacetOption = {
+  type: 'facet-option';
   id: string; // used to verify against taxonomy
   name: string; // used to display for front end
-  count?: number;
-  options: FacetValue[];
   key: string;
-  type: 'facet-option';
+  options: FacetValue[];
 };
 
 export type FacetValue = {
+  type: 'facet-value';
   id: string;
   name: string;
-  facets: FacetOption[];
   key: string;
-  type: 'facet-value';
+  count?: number;
+  facets: FacetOption[];
 };
 
 export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -74,3 +74,22 @@ export type FacetAggRes = {
     // key is split by '>' key
   };
 };
+
+export type FacetOption = {
+  id: string; // used to verify against taxonomy
+  name: string; // used to display for front end
+  count?: number;
+  options: FacetValue[];
+  key: string;
+  type: 'facet-option';
+};
+
+export type FacetValue = {
+  id: string;
+  name: string;
+  facets: FacetOption[];
+  key: string;
+  type: 'facet-value';
+};
+
+export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -131,7 +131,7 @@ function convertToFacetOptions(facetsRes: { [key: string]: FacetBucket }, taxono
         id: bucket._id,
         name: foundFacet.name || '',
         facets: [],
-        key: key,
+        key: facetKey,
         type: 'facet-value',
         count: bucket.count,
       });

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -97,7 +97,7 @@ function _constructFacetResponse(
 }
 
 /**
- * 
+ *
  * @param taxonomy    taxonomy representation of all available facets
  * @returns           root list of FacetOption[], representing taxonomy
  */
@@ -114,7 +114,6 @@ export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
     };
 
     for (const taxonomyFacet of taxonomy[id]) {
-      if (typeof taxonomyFacet !== 'object') continue;
       newFacetOption.options.push(handleFacetValue(id, taxonomyFacet, prefix + id));
     }
 
@@ -131,7 +130,7 @@ export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
     };
 
     for (const key of Object.keys(taxonomyFacet)) {
-      if (typeof taxonomyFacet[key] !== 'object' && taxonomyFacet[key]?.length === undefined) continue;
+      if (!Array.isArray(taxonomyFacet[key])) continue;
       newFacet.facets.push(
         handleFacetOption(taxonomyFacet as unknown as Taxonomy, key, `${prefix}>${taxonomyFacet.name}>`)
       );

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -96,8 +96,11 @@ function _constructFacetResponse(
   }
 }
 
-// TODO: update this to work with new facet structure (children and options)
-// DONE
+/**
+ * 
+ * @param taxonomy    taxonomy representation of all available facets
+ * @returns           root list of FacetOption[], representing taxonomy
+ */
 export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
   const res: FacetOption[] = [];
 

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -8,10 +8,8 @@ import dive from 'dive';
 import fs from 'fs';
 import util from 'util';
 
-import { Manifest, Taxonomy, FacetBucket, FacetDisplayNames, FacetAggRes, FacetOption, FacetValue } from './types';
+import { Manifest, Taxonomy, FacetBucket, TrieFacet, FacetAggRes, FacetOption, FacetValue } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
-
-import { InvalidQuery } from '../Query';
 
 const log = new Logger({
   showTimestamp: true,
@@ -31,69 +29,163 @@ interface FacetRes {
   [key: string]: FacetRes | string | number | undefined;
 }
 
-// TODO: update this to work with new facet structure (children and options)
-export function formatFacetMetaResponse(facetAggRes: FacetAggRes, taxonomyTrie: FacetDisplayNames) {
-  const res: {
-    count: number;
-    facets: FacetRes;
-  } = {
-    count: facetAggRes['count']['lowerBound'],
-    facets: {},
-  };
+export function formatFacetMetaResponse(facetAggRes: FacetAggRes, taxonomyTrie: TrieFacet) {
+  const facetRes: FacetRes = {};
 
-  for (const [facetKey, facetBucket] of Object.entries(facetAggRes['facet'])) {
-    _constructFacetResponse(res.facets, facetKey, facetBucket, taxonomyTrie);
-  }
-  // for each facetAggRes
-  // split the key into parts
-  // and lookup each bucket of aggres
-  return res;
+  const facets: FacetOption[] = convertToFacetOptions(facetAggRes.facet, taxonomyTrie);
+
+  return {
+    count: facetAggRes.count['lowerBound'],
+    facets: facets,
+  };
 }
 
-// generates same response structure as /v2/manifest
-// for facet aggregation results
-// mutates and formats resultsFacet
-function _constructFacetResponse(
-  responseFacets: FacetRes,
-  facetKey: string,
-  facetBucket: FacetBucket,
-  taxonomy: FacetDisplayNames
+function handleFacetValue(
+  facetOption: FacetOption,
+  key: string,
+  id: string,
+  trieFacet: TrieFacet,
+  facetsByFacetKey: { [key: string]: FacetOption | FacetValue }
 ) {
-  let responseRef = responseFacets;
-  let taxRef = taxonomy;
-  try {
-    for (const facetName of facetKey.split('>')) {
-      const taxEntity = taxRef[facetName] as FacetDisplayNames;
-      if (!taxEntity) {
+  facetOption.options.push({
+    id: id,
+    name: trieFacet.name, //
+    facets: [],
+    key: key,
+    type: 'facet-value',
+  });
+
+  facetsByFacetKey[key] = facetOption.options[facetOption.options.length - 1];
+}
+
+function handleFacetOption(
+  facetValue: FacetValue,
+  key: string,
+  id: string,
+  trieFacet: TrieFacet,
+  facetsByFacetKey: { [key: string]: FacetOption | FacetValue }
+) {
+  facetValue.facets.push({
+    id: id,
+    name: trieFacet.name,
+    options: [],
+    key: key,
+    type: 'facet-option',
+  });
+
+  facetsByFacetKey[key] = facetValue.facets[facetValue.facets.length - 1];
+}
+
+function convertToFacetOptions(facetsRes: { [key: string]: FacetBucket }, taxonomyTrie: TrieFacet): FacetOption[] {
+  const res: { facets: FacetOption[] } = {
+    facets: [],
+  };
+  const facetsByFacetKey: { [key: string]: FacetOption | FacetValue } = {};
+  const taxonomyByKey: { [key: string]: TrieFacet } = {};
+  // keep index of partial taxonomy buckets as we add to res
+  // so we don't have to keep searching.
+  // length of number[] should correlate to length of '>' in key
+  const facetKeys = Object.keys(facetsRes).sort();
+
+  for (const facetKey of facetKeys) {
+    const parts = facetKey.split('>');
+    let partialKey = '';
+    let taxonomyRef = taxonomyTrie;
+    let facetRef: FacetOption | FacetValue;
+
+    for (let partIdx = 0; partIdx < parts.length; partIdx++) {
+      const part = parts[partIdx];
+      partialKey = `${partialKey ? partialKey + '>' : ''}${part}`;
+      const parentKey = parts.slice(0, partIdx).join('>');
+      taxonomyRef = taxonomyRef[part] as TrieFacet;
+      if (!taxonomyRef) {
         console.error(`Facet filter does not exist: ${facetKey}`);
         continue;
+      } else {
+        taxonomyByKey[partialKey] = taxonomyRef;
       }
-      responseRef[facetName] = responseRef[facetName] || {
-        name: taxEntity['name'],
-      };
-      responseRef = responseRef[facetName] as FacetRes;
-      taxRef = taxRef[facetName] as FacetDisplayNames;
+
+      // find reference of facet value / facet option
+      if (partIdx === 0) {
+        facetRef = res as unknown as FacetOption;
+      } else {
+        facetRef = facetsByFacetKey[parentKey];
+      }
+
+      if (partIdx % 2 && !facetsByFacetKey[parentKey]) {
+        // handle facet value
+        handleFacetValue(facetRef as FacetOption, partialKey, part, taxonomyRef, facetsByFacetKey);
+      } else if (!facetsByFacetKey[partialKey] && facetsRes[facetKey].buckets.length) {
+        handleFacetOption(facetRef as FacetValue, partialKey, part, taxonomyRef, facetsByFacetKey);
+      }
     }
 
-    for (const bucket of facetBucket['buckets']) {
-      const childFacet = taxRef[bucket._id] as FacetDisplayNames;
-      if (!childFacet) {
-        console.error(
-          `Error: Facets.bucket:  \n ${JSON.stringify(bucket)} \n` +
-            `Does not match taxonomy: \n${JSON.stringify(taxRef)}`
-        );
-        continue;
-      }
-      responseRef[bucket._id] = {
-        ...Object(responseRef[bucket._id]),
-        name: childFacet.name,
-        count: bucket.count,
-      };
+    const target = facetsByFacetKey[facetKey] as FacetOption;
+    if (target) {
+      target.options = [];
     }
-  } catch (e) {
-    console.error(`Error while constructing facet response: ${e}`);
-    throw new InvalidQuery();
+    for (const bucket of facetsRes[facetKey].buckets) {
+      const foundFacet = taxonomyByKey[facetKey]?.[bucket._id] as TrieFacet;
+      const key = facetKey + '>' + bucket._id;
+      target.options.push({
+        id: bucket._id,
+        name: foundFacet.name || '',
+        facets: [],
+        key: key,
+        type: 'facet-value',
+        count: bucket.count,
+      });
+
+      facetsByFacetKey[key] = target.options[target.options.length - 1];
+    }
   }
+
+  return res.facets;
+}
+
+/**
+ *
+ * @param taxonomy
+ * @returns a trie structure of taxonomy.
+ * each node is denoted by a 'name' attribute.
+ * other attributes denotes a new node
+ * ['name' and 'display_name' attributes denote name(s) of facet]
+ * [versions have special boolean attribute of 'stable']
+ */
+export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
+  const res: TrieFacet = {
+    name: '',
+  };
+
+  function addToRes(entityList: TaxonomyEntity[], ref: { [key: string]: any }, property: string) {
+    ref[property] = {
+      name: convertTitleCase(property, property), // convert snakecase to title case
+    };
+    ref = ref[property];
+    for (const taxEntity of entityList) {
+      const entity: Record<string, any> = {
+        name: taxEntity['display_name'] || convertTitleCase(taxEntity['name'], property),
+      };
+      if (property === 'versions' && taxEntity['stable']) {
+        entity['stable'] = true;
+      }
+      for (const key in taxEntity) {
+        if (!Array.isArray(taxEntity[key])) {
+          continue;
+        }
+        addToRes(taxEntity[key] as TaxonomyEntity[], entity, key);
+      }
+      ref[taxEntity['name']] = entity;
+    }
+  }
+
+  for (const stringKey in taxonomy) {
+    if (stringKey === 'name') {
+      continue;
+    }
+    addToRes(taxonomy[stringKey], res as object, stringKey);
+  }
+  return res;
 }
 
 /**
@@ -101,10 +193,10 @@ function _constructFacetResponse(
  * @param taxonomy    taxonomy representation of all available facets
  * @returns           root list of FacetOption[], representing taxonomy
  */
-export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
+export function convertTaxonomyToResponseFormat(taxonomy: Taxonomy): FacetOption[] {
   const res: FacetOption[] = [];
 
-  function handleFacetOption(taxonomy: Taxonomy, id: string, prefix: string): FacetOption {
+  function constructFacetOption(taxonomy: Taxonomy, id: string, prefix: string): FacetOption {
     const newFacetOption: FacetOption = {
       type: 'facet-option',
       id: id,
@@ -114,13 +206,13 @@ export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
     };
 
     for (const taxonomyFacet of taxonomy[id]) {
-      newFacetOption.options.push(handleFacetValue(id, taxonomyFacet, prefix + id));
+      newFacetOption.options.push(constructFacetValue(id, taxonomyFacet, prefix + id));
     }
 
     return newFacetOption;
   }
 
-  function handleFacetValue(taxonomyKey: string, taxonomyFacet: TaxonomyEntity, prefix: string): FacetValue {
+  function constructFacetValue(taxonomyKey: string, taxonomyFacet: TaxonomyEntity, prefix: string): FacetValue {
     const newFacet: FacetValue = {
       type: 'facet-value',
       id: taxonomyFacet.name,
@@ -132,7 +224,7 @@ export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
     for (const key of Object.keys(taxonomyFacet)) {
       if (!Array.isArray(taxonomyFacet[key])) continue;
       newFacet.facets.push(
-        handleFacetOption(taxonomyFacet as unknown as Taxonomy, key, `${prefix}>${taxonomyFacet.name}>`)
+        constructFacetOption(taxonomyFacet as unknown as Taxonomy, key, `${prefix}>${taxonomyFacet.name}>`)
       );
     }
 
@@ -140,7 +232,7 @@ export function convertTaxonomyResponse(taxonomy: Taxonomy): FacetOption[] {
   }
 
   for (const facetOptionKey of Object.keys(taxonomy)) {
-    res.push(handleFacetOption(taxonomy, facetOptionKey, ''));
+    res.push(constructFacetOption(taxonomy, facetOptionKey, ''));
   }
   return res;
 }

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -1,4 +1,4 @@
-import { FacetDisplayNames, Taxonomy } from '../../src/SearchIndex/types';
+import { FacetDisplayNames, FacetOption, Taxonomy } from '../../src/SearchIndex/types';
 
 export const sampleTaxonomy = {
   genres: [{ name: 'reference' }, { name: 'tutorial' }],
@@ -30,65 +30,410 @@ export const sampleTaxonomy = {
   ],
 } as Taxonomy;
 
-export const sampleFacetTrie = {
-  genres: {
+export const sampleFacetTrie = [
+  {
+    type: 'facet-option',
+    id: 'genres',
+    key: 'genres',
     name: 'Genres',
-    reference: { name: 'Reference' },
-    tutorial: { name: 'Tutorial' },
+    options: [
+      {
+        type: 'facet-value',
+        id: 'reference',
+        key: 'genres',
+        name: 'Reference',
+        facets: [{ type: 'facet-option', id: 'name', key: 'genres>reference>name', name: 'Name', options: [] }],
+      },
+      {
+        type: 'facet-value',
+        id: 'tutorial',
+        key: 'genres',
+        name: 'Tutorial',
+        facets: [{ type: 'facet-option', id: 'name', key: 'genres>tutorial>name', name: 'Name', options: [] }],
+      },
+    ],
   },
-  target_platforms: {
+  {
+    type: 'facet-option',
+    id: 'target_platforms',
+    key: 'target_platforms',
     name: 'Target Platforms',
-    atlas: {
-      name: 'Atlas',
-      versions: {
-        name: 'versions',
-        'v1.2': { name: 'v1.2' },
-        master: { name: 'master' },
+    options: [
+      {
+        type: 'facet-value',
+        id: 'atlas',
+        key: 'target_platforms',
+        name: 'Atlas',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>atlas>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>atlas>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.2',
+                key: 'target_platforms>atlas>versions',
+                name: 'v1.2',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>atlas>versions>v1.2>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_platforms>atlas>versions',
+                name: 'master',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>atlas>versions>master>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
-    },
-    'atlas-cli': {
-      name: 'Atlas CLI',
-      versions: {
-        name: 'versions',
-        'v1.2': { name: 'v1.2', stable: true },
-        master: { name: 'master' },
+      {
+        type: 'facet-value',
+        id: 'atlas-cli',
+        key: 'target_platforms',
+        name: 'Atlas CLI',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>atlas-cli>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'display_name',
+            key: 'target_platforms>atlas-cli>display_name',
+            name: 'Display Name',
+            options: [],
+          },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>atlas-cli>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.2',
+                key: 'target_platforms>atlas-cli>versions',
+                name: 'v1.2',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>atlas-cli>versions>v1.2>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_platforms>atlas-cli>versions',
+                name: 'master',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>atlas-cli>versions>master>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
-    },
-    manual: {
-      name: 'Manual',
-      versions: {
-        name: 'versions',
-        'v1.0': { name: 'v1.0' },
-        master: { name: 'master' },
+      {
+        type: 'facet-value',
+        id: 'manual',
+        key: 'target_platforms',
+        name: 'Manual',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>manual>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>manual>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.0',
+                key: 'target_platforms>manual>versions',
+                name: 'v1.0',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>manual>versions>v1.0>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_platforms>manual>versions',
+                name: 'master',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>manual>versions>master>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
-    },
-    'spark-connector': {
-      name: 'Spark Connector',
-      versions: {
-        name: 'versions',
-        'v2.0': { name: 'v2.0' },
-        'v2.1': { name: 'v2.1' },
+      {
+        type: 'facet-value',
+        id: 'spark-connector',
+        key: 'target_platforms',
+        name: 'Spark Connector',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>spark-connector>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'display_name',
+            key: 'target_platforms>spark-connector>display_name',
+            name: 'Display Name',
+            options: [],
+          },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>spark-connector>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v2.0',
+                key: 'target_platforms>spark-connector>versions',
+                name: 'v2.0',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>spark-connector>versions>v2.0>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+              {
+                type: 'facet-value',
+                id: 'v2.1',
+                key: 'target_platforms>spark-connector>versions',
+                name: 'v2.1',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>spark-connector>versions>v2.1>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
-    },
-    node: {
-      name: 'Node',
-      versions: { name: 'versions', 'v4.9': { name: 'v4.9' } },
-    },
-    mongocli: {
-      name: 'Mongo CLI',
-      versions: { name: 'versions', 'v1.0': { name: 'v1.0' } },
-    },
-    'visual-studio-extension': {
-      name: 'Visual Studio Extension',
-      versions: { name: 'versions', current: { name: 'current' } },
-    },
-    golang: {
-      name: 'Golang',
-      versions: { name: 'versions', 'v1.7': { name: 'v1.7' } },
-    },
-    java: {
-      name: 'Java',
-      versions: { name: 'versions', 'v4.3': { name: 'v4.3' } },
-    },
+      {
+        type: 'facet-value',
+        id: 'node',
+        key: 'target_platforms',
+        name: 'Node',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>node>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>node>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v4.9',
+                key: 'target_platforms>node>versions',
+                name: 'v4.9',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>node>versions>v4.9>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'mongocli',
+        key: 'target_platforms',
+        name: 'Mongo CLI',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>mongocli>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'display_name',
+            key: 'target_platforms>mongocli>display_name',
+            name: 'Display Name',
+            options: [],
+          },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>mongocli>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.0',
+                key: 'target_platforms>mongocli>versions',
+                name: 'v1.0',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>mongocli>versions>v1.0>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'visual-studio-extension',
+        key: 'target_platforms',
+        name: 'Visual Studio Extension',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'name',
+            key: 'target_platforms>visual-studio-extension>name',
+            name: 'Name',
+            options: [],
+          },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>visual-studio-extension>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'current',
+                key: 'target_platforms>visual-studio-extension>versions',
+                name: 'current',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>visual-studio-extension>versions>current>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'golang',
+        key: 'target_platforms',
+        name: 'Golang',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>golang>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>golang>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.7',
+                key: 'target_platforms>golang>versions',
+                name: 'v1.7',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>golang>versions>v1.7>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'java',
+        key: 'target_platforms',
+        name: 'Java',
+        facets: [
+          { type: 'facet-option', id: 'name', key: 'target_platforms>java>name', name: 'Name', options: [] },
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_platforms>java>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v4.3',
+                key: 'target_platforms>java>versions',
+                name: 'v4.3',
+                facets: [
+                  {
+                    type: 'facet-option',
+                    id: 'name',
+                    key: 'target_platforms>java>versions>v4.3>name',
+                    name: 'Name',
+                    options: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
-} as FacetDisplayNames;
+] as FacetOption[];

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -30,7 +30,7 @@ export const sampleTaxonomy = {
   ],
 } as Taxonomy;
 
-export const sampleFacetTrie = [
+export const sampleFacetOption = [
   {
     type: 'facet-option',
     id: 'genres',

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -1,4 +1,4 @@
-import { FacetDisplayNames, FacetOption, Taxonomy } from '../../src/SearchIndex/types';
+import { FacetOption, Taxonomy } from '../../src/SearchIndex/types';
 
 export const sampleTaxonomy = {
   genres: [{ name: 'reference' }, { name: 'tutorial' }],

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -42,14 +42,14 @@ export const sampleFacetTrie = [
         id: 'reference',
         key: 'genres',
         name: 'Reference',
-        facets: [{ type: 'facet-option', id: 'name', key: 'genres>reference>name', name: 'Name', options: [] }],
+        facets: [],
       },
       {
         type: 'facet-value',
         id: 'tutorial',
         key: 'genres',
         name: 'Tutorial',
-        facets: [{ type: 'facet-option', id: 'name', key: 'genres>tutorial>name', name: 'Name', options: [] }],
+        facets: [],
       },
     ],
   },
@@ -65,7 +65,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Atlas',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>atlas>name', name: 'Name', options: [] },
           {
             type: 'facet-option',
             id: 'versions',
@@ -77,30 +76,14 @@ export const sampleFacetTrie = [
                 id: 'v1.2',
                 key: 'target_platforms>atlas>versions',
                 name: 'v1.2',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>atlas>versions>v1.2>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
               {
                 type: 'facet-value',
                 id: 'master',
                 key: 'target_platforms>atlas>versions',
                 name: 'master',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>atlas>versions>master>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -112,14 +95,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Atlas CLI',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>atlas-cli>name', name: 'Name', options: [] },
-          {
-            type: 'facet-option',
-            id: 'display_name',
-            key: 'target_platforms>atlas-cli>display_name',
-            name: 'Display Name',
-            options: [],
-          },
           {
             type: 'facet-option',
             id: 'versions',
@@ -131,30 +106,14 @@ export const sampleFacetTrie = [
                 id: 'v1.2',
                 key: 'target_platforms>atlas-cli>versions',
                 name: 'v1.2',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>atlas-cli>versions>v1.2>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
               {
                 type: 'facet-value',
                 id: 'master',
                 key: 'target_platforms>atlas-cli>versions',
                 name: 'master',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>atlas-cli>versions>master>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -166,7 +125,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Manual',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>manual>name', name: 'Name', options: [] },
           {
             type: 'facet-option',
             id: 'versions',
@@ -178,30 +136,14 @@ export const sampleFacetTrie = [
                 id: 'v1.0',
                 key: 'target_platforms>manual>versions',
                 name: 'v1.0',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>manual>versions>v1.0>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
               {
                 type: 'facet-value',
                 id: 'master',
                 key: 'target_platforms>manual>versions',
                 name: 'master',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>manual>versions>master>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -213,14 +155,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Spark Connector',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>spark-connector>name', name: 'Name', options: [] },
-          {
-            type: 'facet-option',
-            id: 'display_name',
-            key: 'target_platforms>spark-connector>display_name',
-            name: 'Display Name',
-            options: [],
-          },
           {
             type: 'facet-option',
             id: 'versions',
@@ -232,30 +166,14 @@ export const sampleFacetTrie = [
                 id: 'v2.0',
                 key: 'target_platforms>spark-connector>versions',
                 name: 'v2.0',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>spark-connector>versions>v2.0>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
               {
                 type: 'facet-value',
                 id: 'v2.1',
                 key: 'target_platforms>spark-connector>versions',
                 name: 'v2.1',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>spark-connector>versions>v2.1>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -267,7 +185,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Node',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>node>name', name: 'Name', options: [] },
           {
             type: 'facet-option',
             id: 'versions',
@@ -279,15 +196,7 @@ export const sampleFacetTrie = [
                 id: 'v4.9',
                 key: 'target_platforms>node>versions',
                 name: 'v4.9',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>node>versions>v4.9>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -299,14 +208,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Mongo CLI',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>mongocli>name', name: 'Name', options: [] },
-          {
-            type: 'facet-option',
-            id: 'display_name',
-            key: 'target_platforms>mongocli>display_name',
-            name: 'Display Name',
-            options: [],
-          },
           {
             type: 'facet-option',
             id: 'versions',
@@ -318,15 +219,7 @@ export const sampleFacetTrie = [
                 id: 'v1.0',
                 key: 'target_platforms>mongocli>versions',
                 name: 'v1.0',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>mongocli>versions>v1.0>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -340,13 +233,6 @@ export const sampleFacetTrie = [
         facets: [
           {
             type: 'facet-option',
-            id: 'name',
-            key: 'target_platforms>visual-studio-extension>name',
-            name: 'Name',
-            options: [],
-          },
-          {
-            type: 'facet-option',
             id: 'versions',
             key: 'target_platforms>visual-studio-extension>versions',
             name: 'versions',
@@ -356,15 +242,7 @@ export const sampleFacetTrie = [
                 id: 'current',
                 key: 'target_platforms>visual-studio-extension>versions',
                 name: 'current',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>visual-studio-extension>versions>current>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -376,7 +254,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Golang',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>golang>name', name: 'Name', options: [] },
           {
             type: 'facet-option',
             id: 'versions',
@@ -388,15 +265,7 @@ export const sampleFacetTrie = [
                 id: 'v1.7',
                 key: 'target_platforms>golang>versions',
                 name: 'v1.7',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>golang>versions>v1.7>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },
@@ -408,7 +277,6 @@ export const sampleFacetTrie = [
         key: 'target_platforms',
         name: 'Java',
         facets: [
-          { type: 'facet-option', id: 'name', key: 'target_platforms>java>name', name: 'Name', options: [] },
           {
             type: 'facet-option',
             id: 'versions',
@@ -420,15 +288,7 @@ export const sampleFacetTrie = [
                 id: 'v4.3',
                 key: 'target_platforms>java>versions',
                 name: 'v4.3',
-                facets: [
-                  {
-                    type: 'facet-option',
-                    id: 'name',
-                    key: 'target_platforms>java>versions>v4.3>name',
-                    name: 'Name',
-                    options: [],
-                  },
-                ],
+                facets: [],
               },
             ],
           },

--- a/tests/unit/SearchIndex.test.ts
+++ b/tests/unit/SearchIndex.test.ts
@@ -1,5 +1,5 @@
 import { strictEqual, deepStrictEqual } from 'assert';
-import { joinUrl, convertTaxonomyResponse } from '../../src/SearchIndex/util';
+import { joinUrl, convertTaxonomyToResponseFormat } from '../../src/SearchIndex/util';
 import { sampleFacetOption, sampleTaxonomy } from '../resources/utils-data';
 
 describe('SearchIndex', function () {
@@ -8,11 +8,11 @@ describe('SearchIndex', function () {
     strictEqual(joinUrl('https://example.com', 'foo'), 'https://example.com/foo');
   });
 
-  describe('convertTaxonomyResponse', () => {
+  describe('convertTaxonomyToResponseFormat', () => {
     it('converts taxonomy object into a trie structure', () => {
       const input = sampleTaxonomy;
       const expected = sampleFacetOption;
-      deepStrictEqual(convertTaxonomyResponse(input), expected);
+      deepStrictEqual(convertTaxonomyToResponseFormat(input), expected);
     });
   });
 });

--- a/tests/unit/SearchIndex.test.ts
+++ b/tests/unit/SearchIndex.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual, deepStrictEqual } from 'assert';
 import { joinUrl, convertTaxonomyResponse } from '../../src/SearchIndex/util';
-import { sampleFacetTrie, sampleTaxonomy } from '../resources/utils-data';
+import { sampleFacetOption, sampleTaxonomy } from '../resources/utils-data';
 
 describe('SearchIndex', function () {
   it('correctly joins base URLs with slugs', function () {
@@ -11,7 +11,7 @@ describe('SearchIndex', function () {
   describe('convertTaxonomyResponse', () => {
     it('converts taxonomy object into a trie structure', () => {
       const input = sampleTaxonomy;
-      const expected = sampleFacetTrie;
+      const expected = sampleFacetOption;
       deepStrictEqual(convertTaxonomyResponse(input), expected);
     });
   });


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-4048)

**Description:** This PR is intended to update the simplicity of our `/v2/status` route for the front end to easily render and use search facet filters with bare minimum of knowledge. The master list of our taxonomy will be represented as a list of [Facet Options](https://github.com/mongodb/docs-search-transport/pull/76/files#diff-2471679ba3ccc57dfd4dca806917d9d696f93bbc145984f7820ca4edfdcfc121R78-R85), which the front end can easily iterate over and decide between **group of checkboxes** and **checkbox filter**

[Current status response](https://docs-search-transport.mongodb.com/v2/status)
[Staged status response](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/status)

Test cases have been updated to reflected the change

**Note:** for the Front End have responsive facet filters, it will have to use the `/v2/search/meta` route for refreshed facets that are filtered by each other. Follow up PR incoming. This current route is being refactored and not functioning, and this PR should not be merged until the route has been addressed. Specifics of changes are in first comment below V
