### PR TITLE
DOP-4048: responsive facet responses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4048'
+      - 'refs/heads/DOP-4048-responsive'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -267,7 +267,7 @@ export default class Marian {
     };
     Object.assign(headers, STANDARD_HEADERS);
     checkAllowedOrigin(req.headers.origin, headers);
-    const responseBody = JSON.stringify(this.index.convertedTaxonomy);
+    const responseBody = JSON.stringify(this.index.responseFacets);
     res.writeHead(200, headers);
     res.end(responseBody);
   }

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 import { getFacetAggregationStages, tokenize } from './util';
-import { Document, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
+import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
 

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 
-import { Document, FacetAggregationStage, FacetDisplayNames, FacetOption } from '../SearchIndex/types';
+import { Document, FacetAggregationStage, FacetOption } from '../SearchIndex/types';
 
 const atomicPhraseMap: Record<string, string> = {
   ops: 'manager',
@@ -80,14 +80,23 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return filter;
 };
 
-// TODO: update this to work with new facet structure (children and options)
 export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
   const facetKeysForAgg: FacetAggregationStage = {};
 
-  // TODO: traverse all of taxonomy to get facets for meta
-  for (const facetOption of taxonomy) {
-    console.log(facetOption);
+  function getKeysFromFacetOptions(facetOptions: FacetOption[]) {
+    for (const facetOption of facetOptions) {
+      facetKeysForAgg[facetOption.key] = {
+        type: 'string',
+        path: `facets.${facetOption.key}`,
+      };
+      for (const facetValue of facetOption.options) {
+        if (facetValue.facets?.length) {
+          getKeysFromFacetOptions(facetValue.facets);
+        }
+      }
+    }
   }
 
+  getKeysFromFacetOptions(taxonomy);
   return facetKeysForAgg;
 };

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -19,7 +19,7 @@ import {
   Taxonomy,
   FacetOption,
   FacetAggRes,
-  FacetDisplayNames,
+  TrieFacet,
 } from './types';
 
 const log = new Logger({
@@ -37,7 +37,7 @@ export class SearchIndex {
   documents: Collection<DatabaseDocument>;
   unindexable: Collection<DatabaseDocument>;
   // taxonomy: Taxonomy;
-  trieFacets: FacetDisplayNames;
+  trieFacets: TrieFacet;
   responseFacets: FacetOption[];
 
   constructor(manifestSource: string, client: MongoClient, databaseName: string) {
@@ -50,7 +50,9 @@ export class SearchIndex {
     this.documents = this.db.collection<DatabaseDocument>('documents');
     this.unindexable = this.db.collection<DatabaseDocument>('unindexable');
     this.lastRefresh = null;
-    this.trieFacets = {};
+    this.trieFacets = {
+      name: '',
+    };
     this.responseFacets = [];
   }
 

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -3,9 +3,9 @@ import assert from 'assert';
 import Logger from 'basic-logger';
 import { MongoClient, Collection, TransactionOptions, AnyBulkWriteOperation, Db, ClientSession } from 'mongodb';
 
-import { convertTaxonomyResponse, formatFacetMetaResponse, getManifests, joinUrl } from './util';
+import { convertTaxonomyToResponseFormat, convertTaxonomyToTrie, formatFacetMetaResponse, getManifests, joinUrl } from './util';
 import { Query } from '../Query';
-import { Document, Manifest, DatabaseDocument, RefreshInfo, Taxonomy, FacetOption, FacetAggRes } from './types';
+import { Document, Manifest, DatabaseDocument, RefreshInfo, Taxonomy, FacetOption, FacetAggRes, FacetDisplayNames } from './types';
 
 const log = new Logger({
   showTimestamp: true,
@@ -21,8 +21,9 @@ export class SearchIndex {
   lastRefresh: RefreshInfo | null;
   documents: Collection<DatabaseDocument>;
   unindexable: Collection<DatabaseDocument>;
-  taxonomy: Taxonomy;
-  convertedTaxonomy: FacetOption[];
+  // taxonomy: Taxonomy;
+  trieFacets: FacetDisplayNames;
+  responseFacets: FacetOption[];
 
   constructor(manifestSource: string, client: MongoClient, databaseName: string) {
     this.currentlyIndexing = false;
@@ -34,8 +35,8 @@ export class SearchIndex {
     this.documents = this.db.collection<DatabaseDocument>('documents');
     this.unindexable = this.db.collection<DatabaseDocument>('unindexable');
     this.lastRefresh = null;
-    this.taxonomy = {};
-    this.convertedTaxonomy = [];
+    this.trieFacets = {};
+    this.responseFacets = [];
   }
 
   async search(query: Query, searchProperty: string[] | null, pageNumber?: number) {
@@ -45,16 +46,12 @@ export class SearchIndex {
   }
 
   async fetchFacets(query: Query, searchProperty: string[] | null) {
-    const metaAggregationQuery = query.getMetaQuery(searchProperty, this.convertedTaxonomy);
+    const metaAggregationQuery = query.getMetaQuery(searchProperty, this.responseFacets);
     const cursor = this.documents.aggregate(metaAggregationQuery);
     try {
       // TODO: re-implement
-      // const aggRes = await cursor.toArray();
-      // const res = formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.convertedTaxonomy);
-      return {
-        count: 0,
-        aggRes: null,
-      };
+      const aggRes = await cursor.toArray();
+      return formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.trieFacets);
     } catch (e) {
       log.error(`Error while fetching facets: ${JSON.stringify(e)}`);
       throw e;
@@ -62,8 +59,9 @@ export class SearchIndex {
   }
 
   async load(taxonomy: Taxonomy, manifestSource?: string, refreshManifests = true): Promise<RefreshInfo | undefined> {
-    this.taxonomy = taxonomy;
-    this.convertedTaxonomy = convertTaxonomyResponse(taxonomy);
+    // this.taxonomy = taxonomy;
+    this.responseFacets = convertTaxonomyToResponseFormat(taxonomy);
+    this.trieFacets = convertTaxonomyToTrie(taxonomy);
 
     if (!refreshManifests) {
       return;

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -3,9 +3,24 @@ import assert from 'assert';
 import Logger from 'basic-logger';
 import { MongoClient, Collection, TransactionOptions, AnyBulkWriteOperation, Db, ClientSession } from 'mongodb';
 
-import { convertTaxonomyToResponseFormat, convertTaxonomyToTrie, formatFacetMetaResponse, getManifests, joinUrl } from './util';
+import {
+  convertTaxonomyToResponseFormat,
+  convertTaxonomyToTrie,
+  formatFacetMetaResponse,
+  getManifests,
+  joinUrl,
+} from './util';
 import { Query } from '../Query';
-import { Document, Manifest, DatabaseDocument, RefreshInfo, Taxonomy, FacetOption, FacetAggRes, FacetDisplayNames } from './types';
+import {
+  Document,
+  Manifest,
+  DatabaseDocument,
+  RefreshInfo,
+  Taxonomy,
+  FacetOption,
+  FacetAggRes,
+  FacetDisplayNames,
+} from './types';
 
 const log = new Logger({
   showTimestamp: true,

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -36,7 +36,6 @@ export class SearchIndex {
   lastRefresh: RefreshInfo | null;
   documents: Collection<DatabaseDocument>;
   unindexable: Collection<DatabaseDocument>;
-  // taxonomy: Taxonomy;
   trieFacets: TrieFacet;
   responseFacets: FacetOption[];
 
@@ -76,7 +75,6 @@ export class SearchIndex {
   }
 
   async load(taxonomy: Taxonomy, manifestSource?: string, refreshManifests = true): Promise<RefreshInfo | undefined> {
-    // this.taxonomy = taxonomy;
     this.responseFacets = convertTaxonomyToResponseFormat(taxonomy);
     this.trieFacets = convertTaxonomyToTrie(taxonomy);
 

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -76,20 +76,20 @@ export type FacetAggRes = {
 };
 
 export type FacetOption = {
+  type: 'facet-option';
   id: string; // used to verify against taxonomy
   name: string; // used to display for front end
-  count?: number;
-  options: FacetValue[];
   key: string;
-  type: 'facet-option';
+  options: FacetValue[];
 };
 
 export type FacetValue = {
+  type: 'facet-value';
   id: string;
   name: string;
-  facets: FacetOption[];
   key: string;
-  type: 'facet-value';
+  count?: number;
+  facets: FacetOption[];
 };
 
 export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -53,9 +53,9 @@ export interface TaxonomyEntity {
 export type Taxonomy = Record<string, TaxonomyEntity[]>;
 
 // Facets
-export type FacetDisplayNames = {
-  name?: string;
-  [key: string]: FacetDisplayNames | string | boolean | undefined;
+export type TrieFacet = {
+  name: string;
+  [key: string]: TrieFacet | string | boolean | undefined;
 };
 
 export type FacetBucket = {

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -42,7 +42,6 @@ export function formatFacetMetaResponse(facetAggRes: FacetAggRes, taxonomyTrie: 
   };
 }
 
-
 function handleFacetValue(
   facetOption: FacetOption,
   key: string,
@@ -102,7 +101,7 @@ function convertToFacetOptions(
     for (let partIdx = 0; partIdx < parts.length; partIdx++) {
       const part = parts[partIdx];
       partialKey = `${partialKey ? partialKey + '>' : ''}${part}`;
-      const parentKey = parts.slice(0, partIdx).join('>')
+      const parentKey = parts.slice(0, partIdx).join('>');
       taxonomyRef = taxonomyRef[part] as FacetDisplayNames;
       if (!taxonomyRef) {
         console.error(`Facet filter does not exist: ${facetKey}`);
@@ -121,8 +120,7 @@ function convertToFacetOptions(
       if (partIdx % 2 && !facetsByFacetKey[parentKey]) {
         // handle facet value
         handleFacetValue(facetRef as FacetOption, partialKey, part, taxonomyRef, facetsByFacetKey);
-      }
-      else if (!facetsByFacetKey[partialKey] && facetsRes[facetKey].buckets.length) {
+      } else if (!facetsByFacetKey[partialKey] && facetsRes[facetKey].buckets.length) {
         handleFacetOption(facetRef as FacetValue, partialKey, part, taxonomyRef, facetsByFacetKey);
       }
     }

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -1,4 +1,4 @@
-import { FacetDisplayNames, FacetOption, Taxonomy } from '../../src/SearchIndex/types';
+import { FacetOption, Taxonomy } from '../../src/SearchIndex/types';
 
 export const sampleTaxonomy = {
   genres: [{ name: 'reference' }, { name: 'tutorial' }],

--- a/tests/unit/SearchIndex.test.ts
+++ b/tests/unit/SearchIndex.test.ts
@@ -1,5 +1,5 @@
 import { strictEqual, deepStrictEqual } from 'assert';
-import { joinUrl, convertTaxonomyResponse } from '../../src/SearchIndex/util';
+import { joinUrl, convertTaxonomyToResponseFormat } from '../../src/SearchIndex/util';
 import { sampleFacetTrie, sampleTaxonomy } from '../resources/utils-data';
 
 describe('SearchIndex', function () {
@@ -8,11 +8,11 @@ describe('SearchIndex', function () {
     strictEqual(joinUrl('https://example.com', 'foo'), 'https://example.com/foo');
   });
 
-  describe('convertTaxonomyResponse', () => {
+  describe('convertTaxonomyToResponseFormat', () => {
     it('converts taxonomy object into a trie structure', () => {
       const input = sampleTaxonomy;
       const expected = sampleFacetTrie;
-      deepStrictEqual(convertTaxonomyResponse(input), expected);
+      deepStrictEqual(convertTaxonomyToResponseFormat(input), expected);
     });
   });
 });


### PR DESCRIPTION
[Pre-req PR](https://github.com/mongodb/docs-search-transport/pull/76)

[JIRA](https://jira.mongodb.org/browse/DOP-4048)

**Goal**: This PR is intended to update the functionality and format of our `/v2/search/meta` route, as to match the new format of the `/v2/status` route. This allows for front end to have dynamic facets with a single API query to the aforementioned route with query parameters for filters ([example](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=atlas&facets.target_product=atlas))

**Description:**
- `/v2/search/meta` route has been updated from a trie structure of shallow level of taxonomy, to a list structure as described in DOP-4048 for all depths. Front end can decide to show/hide based off the route response, without any data manipulation (with some special case logic of course..)

[Current meta search response](https://docs-search-transport.mongodb.com/v2/search/meta?q=atlas)
[Staged status response](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=atlas)