### PR TITLE
DOP-4075: fix meta results for 0 count

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4075'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-4075
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4075
+      - 'refs/heads/DOP-4075'
 
 steps:
   - name: publish-staging


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-4075)

**Description:**  Were returning 500 errors when getting 0 results for metadata. When catching manually:

```
VM925:1 Uncaught TypeError: Cannot read properties of undefined (reading 'options')
    at eval (eval at handleFacetValue (util.js:1:1), <anonymous>:1:15)
    at handleFacetValue (util.js:36:17)
    at convertToFacetOptions (util.js:91:17)
    at Object.formatFacetMetaResponse (util.js:28:20)
    at SearchIndex.fetchFacets (index.js:40:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Marian.handleMetaSearch (index.js:189:23)
```

This is happening because we are trying to recursively put child buckets into parent buckets that DNE. Added a skip to this function and successfully returning 0 results.


[Prod meta search results for *valid* query](https://docs-search-transport.mongodb.com/v2/search/meta?q=mongodb)
[Prod meta search results for *invalid* query - no response](https://docs-search-transport.mongodb.com/v2/search/meta?q=mongodbquerydne)

[Stage search results for *valid* query, should remain the same
](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=mongodb)[Stage search results for *invalid* query - shows 0 results and empty facets
](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/search/meta?q=mongodbquerydne)