### PR TITLE
DOP-4071: allow either or/and for facet filters when performing search

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4071'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-4071'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -234,7 +234,7 @@ export default class Marian {
     }
 
     const filters = extractFacetFilters(parsedUrl.searchParams);
-    const query = new Query(rawQuery, filters);
+    const query = new Query(rawQuery);
 
     let searchProperty = parsedUrl.searchParams.getAll('searchProperty') || null;
     if (typeof searchProperty === 'string') {
@@ -242,7 +242,8 @@ export default class Marian {
     }
 
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    return this.index.search(query, searchProperty, pageNumber);
+    const combineFilters = Boolean(parsedUrl.searchParams.get('combineFilters'));
+    return this.index.search(query, searchProperty, filters, pageNumber, combineFilters);
   }
 
   private async fetchTaxonomy(url: string) {
@@ -279,7 +280,8 @@ export default class Marian {
     }
 
     const filters = extractFacetFilters(parsedUrl.searchParams);
-    const query = new Query(rawQuery, filters);
+    const combineFilters = Boolean(parsedUrl.searchParams.get('combineFilters'));
+    const query = new Query(rawQuery);
 
     let searchProperty = parsedUrl.searchParams.getAll('searchProperty') || null;
     if (typeof searchProperty === 'string') {
@@ -287,7 +289,7 @@ export default class Marian {
     }
 
     try {
-      return this.index.fetchFacets(query, searchProperty);
+      return this.index.fetchFacets(query, searchProperty, filters, combineFilters);
     } catch (e) {
       console.error(`Error fetching facet metadata: ${JSON.stringify(e)}`);
       throw e;

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -15,7 +15,6 @@ export class Query {
   terms: Set<string>;
   phrases: string[];
   rawQuery: string;
-  // filters: Filter<Document>;
 
   /**
    * Create a new query.
@@ -26,7 +25,6 @@ export class Query {
     this.terms = new Set();
     this.phrases = [];
     this.rawQuery = queryString;
-    // this.filters = filters || {};
 
     const parts = queryString.split(/((?:\s+|^)"[^"]+"(?:\s+|$))/);
     let inQuotes = false;

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -47,37 +47,25 @@ export function tokenize(text: string, fuzzy: boolean): string[] {
   return tokens;
 }
 
-export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<Document> => {
+export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<Document>[] => {
   // query should be in form of:
-  // q=test&facets.target_platforms>manual>versions=v6.0&facets.target_platforms=atlas
-  // where each query param starting with 'facets.' denotes a filter and possible expansion
-  // {
-  //   "facets.target_platforms": ["manual", "atlas"],
-  //   "facets.target_platforms>manual>versions": ["v6.0"]
-  // }
-  const filter: Filter<Document> = {};
+  // q=test&facets.target_product>manual>versions=v6.0&facets.target_product=atlas
+  // where each query param starting with 'facets.' denotes a filter
+  const FACET_PREFIX = 'facets.';
+  const filters: Filter<Document>[] = [];
   for (const [key, value] of searchParams) {
-    if (!key.startsWith('facets.')) {
+    if (!key.startsWith(FACET_PREFIX)) {
       continue;
     }
-    const facetNames = key.replace('facets.', '').split('>');
-    // hierarchy facets denoted by >
-    // each facet node requires a facet property, at every even level
-    for (let facetIdx = 0; facetIdx < facetNames.length; facetIdx += 2) {
-      const facetName = facetNames[facetIdx];
-      // construct partial facet name
-      const prefix = facetIdx === 0 ? '' : facetNames.slice(0, facetIdx).join('>') + '>';
-      const facetKey = `facets.${prefix}${facetName}`;
-      if (!filter[facetKey]) {
-        filter[facetKey] = [];
-      }
 
-      // the value is the next key in query param, or if there is no next key, the value itself
-      const facetValue = facetIdx === facetNames.length - 1 ? value : facetNames[facetIdx + 1];
-      filter[facetKey].push(facetValue);
-    }
+    filters.push({
+      phrase: {
+        query: value,
+        path: key,
+      },
+    });
   }
-  return filter;
+  return filters;
 };
 
 export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -32,7 +32,7 @@ describe('Searching', function () {
 
   // Test variants of searchProperty
   it('should properly handle incorrect urls in manifests', async () => {
-    let result = await index.search(new Query('manual'), ['manual-v5.1']);
+    let result = await index.search(new Query('manual'), ['manual-v5.1'], []);
     strictEqual(result[0].url, 'https://docs.mongodb.com/v5.1/index.html');
   });
 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-4071)

**Description:** PR provides an optional URL query param that allows users to dictate whether facets are combined using an OR/AND operator. Previously, all query params at different levels were treated as **AND** queries, and could therefore result in no results.

[Example of two filters passed and returning 0 results on prod.](https://docs-search-transport.mongodb.com/search?q=mongodb&facets.target_product=compass&facets.target_product%3Erealm%3Esub_product=web) Selected facets are `facets.target_product=compass` and `facets.target_product>realm>sub_product=web` but these are being treated as AND queries, and thus returning 0 results. ([see splunk log for aggregation query](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1696958328.580445&offset=12&latest_time=))

**Results:**

[Same query on branch returns results in stage (with default OR combination)
](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=mongodb&page=1&facets.target_product=compass&facets.target_product%3Erealm%3Esub_product=web)

[Splunk log showing OR combination
](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1696958694.581412&offset=2&latest_time=)

[Same query on branch shows no results when using AND combination
](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=mongodb&page=1&facets.target_product=compass&facets.target_product%3Erealm%3Esub_product=web&combineFilters=true)

[Splunk log showing AND combination](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=1696958694.581412&offset=0&latest_time=)


With these changes, the default mechanism will be an "OR" combination of facets, and users have the option to combine them via URL query param `combineFilters`