### PR TITLE
DOP-4065: return search results' facets (in desired format)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-4065'
 
 steps:
   - name: publish-staging

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,5 +1,5 @@
 import { Filter } from 'mongodb';
-import { getFacetAggregationStages, tokenize } from './util';
+import { getFacetAggregationStages, getProjectionAndFormatStages, tokenize } from './util';
 import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
@@ -239,15 +239,7 @@ export class Query {
     const RES_COUNT = 50;
     const PAGINATED_RES_COUNT = 10;
     // projection
-    agg.push({
-      $project: {
-        _id: 0,
-        title: 1,
-        preview: 1,
-        url: 1,
-        searchProperty: 1,
-      },
-    });
+    agg.push(...getProjectionAndFormatStages());
     // count limit
     if (!page) {
       agg.push({ $limit: RES_COUNT });

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -107,7 +107,10 @@ export const getProjectionAndFormatStages = (): Filter<Document>[] => [
   {
     // unwinds each {facets: [k: string, v: string[]]} to its own document
     // so it becomes { facets: {k: string, v: string[] } }
-    $unwind: '$facets',
+    $unwind: {
+      path: '$facets',
+      preserveNullAndEmptyArrays: true
+    },
   },
   {
     $project: {
@@ -132,7 +135,10 @@ export const getProjectionAndFormatStages = (): Filter<Document>[] => [
   },
   {
     // unwind all nested values
-    $unwind: '$values',
+    $unwind: {
+      path: '$values',
+      preserveNullAndEmptyArrays: true
+    },
   },
   {
     // group all unnested values and keys back

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -109,7 +109,7 @@ export const getProjectionAndFormatStages = (): Filter<Document>[] => [
     // so it becomes { facets: {k: string, v: string[] } }
     $unwind: {
       path: '$facets',
-      preserveNullAndEmptyArrays: true
+      preserveNullAndEmptyArrays: true,
     },
   },
   {
@@ -137,7 +137,7 @@ export const getProjectionAndFormatStages = (): Filter<Document>[] => [
     // unwind all nested values
     $unwind: {
       path: '$values',
-      preserveNullAndEmptyArrays: true
+      preserveNullAndEmptyArrays: true,
     },
   },
   {

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -88,3 +88,79 @@ export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
   getKeysFromFacetOptions(taxonomy);
   return facetKeysForAgg;
 };
+
+export const getProjectionAndFormatStages = (): Filter<Document>[] => [
+  {
+    $project: {
+      _id: 1,
+      title: 1,
+      preview: 1,
+      url: 1,
+      searchProperty: 1,
+      facets: {
+        // facets are originally stored as {facets: { string: string[] }}
+        // this converts to {facets: [k: string, v: string[]]}
+        $objectToArray: '$facets',
+      },
+    },
+  },
+  {
+    // unwinds each {facets: [k: string, v: string[]]} to its own document
+    // so it becomes { facets: {k: string, v: string[] } }
+    $unwind: '$facets',
+  },
+  {
+    $project: {
+      // project key and values to its own document
+      // so we can unwind values
+      key: '$facets.k',
+      values: {
+        $map: {
+          input: '$facets.v',
+          as: 'value',
+          in: {
+            id: '$$value',
+          },
+        },
+      },
+      _id: 1,
+      title: 1,
+      preview: 1,
+      url: 1,
+      searchProperty: 1,
+    },
+  },
+  {
+    // unwind all nested values
+    $unwind: '$values',
+  },
+  {
+    // group all unnested values and keys back
+    $group: {
+      _id: '$_id',
+      title: {
+        $first: '$title',
+      },
+      preview: {
+        $first: '$preview',
+      },
+      url: {
+        $first: '$url',
+      },
+      searchProperty: {
+        $first: '$searchProperty',
+      },
+      facets: {
+        $push: {
+          key: '$key',
+          id: '$values.id',
+        },
+      },
+    },
+  },
+  {
+    $project: {
+      _id: 0,
+    },
+  },
+];

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -20,7 +20,7 @@ describe('Searching', function () {
   before('Loading test data', async function () {
     await client.connect();
     index = new SearchIndex('dir:tests/integration/search_test_data/', client, TEST_DATABASE);
-    const result = await index.load({} as Taxonomy);
+    const result = await index.load({} as Taxonomy, 'dir:tests/integration/search_test_data/');
     await index.createRecommendedIndexes();
 
     // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-4065)

See second bullet point for A/C: `/search route returns documents with "facets" field`

This PR is intended to return the `document.facets` fields in a similar format as the [/v2/status response](https://docs-search-transport.docs.staging.corp.mongodb.com/v2/status), namely with facet values having `{key, id}` properties. This allows for front end to map this to an existing facet from the above response.

[Current search results do not return `facets` field](https://docs-search-transport.mongodb.com/search?q=meta)

[Staging branch returns `facets` field, along with all previous fields in the above example](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=meta)