### PR TITLE
DOP-4065: fix projection

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4065-fix-projection'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4065'
+      - 'refs/heads/DOP-4065-fix-projection'
 
 steps:
   - name: publish-staging

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -92,81 +92,32 @@ export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
 export const getProjectionAndFormatStages = (): Filter<Document>[] => [
   {
     $project: {
-      _id: 1,
+      _id: 0,
       title: 1,
       preview: 1,
       url: 1,
       searchProperty: 1,
       facets: {
-        // facets are originally stored as {facets: { string: string[] }}
-        // this converts to {facets: [k: string, v: string[]]}
-        $objectToArray: '$facets',
-      },
-    },
-  },
-  {
-    // unwinds each {facets: [k: string, v: string[]]} to its own document
-    // so it becomes { facets: {k: string, v: string[] } }
-    $unwind: {
-      path: '$facets',
-      preserveNullAndEmptyArrays: true,
-    },
-  },
-  {
-    $project: {
-      // project key and values to its own document
-      // so we can unwind values
-      key: '$facets.k',
-      values: {
-        $map: {
-          input: '$facets.v',
-          as: 'value',
+        $reduce: {
+          input: { $objectToArray: '$facets' },
+          initialValue: [],
           in: {
-            id: '$$value',
+            $concatArrays: [
+              '$$value',
+              {
+                $map: {
+                  input: '$$this.v',
+                  as: 'facetValue',
+                  in: {
+                    id: '$$facetValue',
+                    key: '$$this.k',
+                  },
+                },
+              },
+            ],
           },
         },
       },
-      _id: 1,
-      title: 1,
-      preview: 1,
-      url: 1,
-      searchProperty: 1,
-    },
-  },
-  {
-    // unwind all nested values
-    $unwind: {
-      path: '$values',
-      preserveNullAndEmptyArrays: true,
-    },
-  },
-  {
-    // group all unnested values and keys back
-    $group: {
-      _id: '$_id',
-      title: {
-        $first: '$title',
-      },
-      preview: {
-        $first: '$preview',
-      },
-      url: {
-        $first: '$url',
-      },
-      searchProperty: {
-        $first: '$searchProperty',
-      },
-      facets: {
-        $push: {
-          key: '$key',
-          id: '$values.id',
-        },
-      },
-    },
-  },
-  {
-    $project: {
-      _id: 0,
     },
   },
 ];


### PR DESCRIPTION
**Context:**

[Previous PR had introduced a way](https://github.com/mongodb/docs-search-transport/pull/82/files#diff-244d01de0824eda50531865572bc5dfaf1c3325fcb645aa6012177cfbdbb1017R145) of re-ordering search documents when "grouping" by unnested facet properties. To mitigate this issue, resorted to remove the unnesting and grouping, and doing the facet object formatting in the "projection" step.

Now, order is preserved from the $search step, and projection only changes each document's "facets" property.

[results ordered on prod](https://docs-search-transport.mongodb.com/search?q=create-atlas-account)

[test results order preserved on stage, with facets formatted](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=create-atlas-account) (some results may be missing only due to data being different in stage+prod)

[test results on prod 2](https://docs-search-transport.mongodb.com/search?q=$and)

[test results on stage 2](https://docs-search-transport.docs.staging.corp.mongodb.com/search?q=$and)