### PR TITLE
DOP-4089: treat same level selections as "or"

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -120,7 +120,7 @@ export default class Marian {
 
     try {
       await this.load();
-    } catch (err) {
+    } catch (err: any) {
       log.error(err);
       headers['Content-Type'] = 'application/json';
       const body = JSON.stringify({ errors: [err] });
@@ -242,8 +242,7 @@ export default class Marian {
     }
 
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    const combineFilters = Boolean(parsedUrl.searchParams.get('combineFilters'));
-    return this.index.search(query, searchProperty, filters, pageNumber, combineFilters);
+    return this.index.search(query, searchProperty, filters, pageNumber);
   }
 
   private async fetchTaxonomy(url: string) {
@@ -280,7 +279,6 @@ export default class Marian {
     }
 
     const filters = extractFacetFilters(parsedUrl.searchParams);
-    const combineFilters = Boolean(parsedUrl.searchParams.get('combineFilters'));
     const query = new Query(rawQuery);
 
     let searchProperty = parsedUrl.searchParams.getAll('searchProperty') || null;
@@ -289,7 +287,7 @@ export default class Marian {
     }
 
     try {
-      return this.index.fetchFacets(query, searchProperty, filters, combineFilters);
+      return this.index.fetchFacets(query, searchProperty, filters);
     } catch (e) {
       console.error(`Error fetching facet metadata: ${JSON.stringify(e)}`);
       throw e;

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -172,8 +172,8 @@ export class Query {
     }
 
     if (filters?.length) {
-      // if facet filters are passed as "or",
-      // they must match at least one
+      // facet filters are passed as nested compounds
+      // each compound (as a whole) must be matched
       compound.must = compound.must.concat(filters);
     }
 

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -59,7 +59,7 @@ export class Query {
     }
   }
 
-  getCompound(searchProperty: string[] | null, filters: Filter<Document>[], combineFilters = false) {
+  getCompound(searchProperty: string[] | null, filters: Filter<Document>[]) {
     const terms = Array.from(this.terms);
     const parts: any[] = [];
     const searchPropertyMapping = getPropertyMapping();
@@ -174,28 +174,14 @@ export class Query {
     if (filters?.length) {
       // if facet filters are passed as "or",
       // they must match at least one
-      if (!combineFilters) {
-        compound.must.push({
-          compound: {
-            should: filters,
-            minimumShouldMatch: 1,
-          },
-        });
-      } else {
-        compound.must = compound.must.concat(filters);
-      }
+      compound.must = compound.must.concat(filters);
     }
 
     return compound;
   }
 
-  getMetaQuery(
-    searchProperty: string[] | null,
-    taxonomy: FacetOption[],
-    filters: Filter<Document>[],
-    combineFilters = false
-  ) {
-    const compound = this.getCompound(searchProperty, filters, combineFilters);
+  getMetaQuery(searchProperty: string[] | null, taxonomy: FacetOption[], filters: Filter<Document>[]) {
+    const compound = this.getCompound(searchProperty, filters);
 
     const facets = getFacetAggregationStages(taxonomy);
 
@@ -214,16 +200,11 @@ export class Query {
     return agg;
   }
 
-  getAggregationQuery(
-    searchProperty: string[] | null,
-    filters: Filter<Document>[],
-    page?: number,
-    combineFilters = false
-  ): any[] {
+  getAggregationQuery(searchProperty: string[] | null, filters: Filter<Document>[], page?: number): any[] {
     if (page && page < 1) {
       throw new InvalidQuery('Invalid page');
     }
-    const compound = this.getCompound(searchProperty, filters, combineFilters);
+    const compound = this.getCompound(searchProperty, filters);
 
     const agg: Filter<Document>[] = [
       {

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -53,14 +53,24 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   // where each query param starting with 'facets.' denotes a filter
   const FACET_PREFIX = 'facets.';
   const filters: Filter<Document>[] = [];
+
+  // values with same keys should be treated as OR
+  // store in hash with one pass and another pass of the hash to filters
+  const queryParamLists: { [key: string]: string[] } = {};
+
   for (const [key, value] of searchParams) {
     if (!key.startsWith(FACET_PREFIX)) {
       continue;
     }
 
+    queryParamLists[key] = queryParamLists[key] || [];
+    queryParamLists[key].push(value);
+  }
+
+  for (const [key, values] of Object.entries(queryParamLists)) {
     filters.push({
       phrase: {
-        query: value,
+        query: values,
         path: key,
       },
     });

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -1,6 +1,6 @@
 import { Filter } from 'mongodb';
 
-import { Document, FacetAggregationStage, FacetOption, TrieFacet } from '../SearchIndex/types';
+import { Document, FacetAggregationStage, FacetOption } from '../SearchIndex/types';
 
 const atomicPhraseMap: Record<string, string> = {
   ops: 'manager',

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -47,9 +47,7 @@ export function tokenize(text: string, fuzzy: boolean): string[] {
   return tokens;
 }
 
-export const extractFacetFilters = (
-  searchParams: URL['searchParams']
-): Filter<Document>[] => {
+export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<Document>[] => {
   // query should be in form of:
   // q=test&facets.target_product>manual>versions=v6.0&facets.target_product=atlas
   // where each query param starting with 'facets.' denotes a filter

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -55,22 +55,13 @@ export class SearchIndex {
     this.responseFacets = [];
   }
 
-  async search(
-    query: Query,
-    searchProperty: string[] | null,
-    filters: Filter<Document>[],
-    pageNumber?: number
-  ) {
+  async search(query: Query, searchProperty: string[] | null, filters: Filter<Document>[], pageNumber?: number) {
     const aggregationQuery = query.getAggregationQuery(searchProperty, filters, pageNumber);
     const cursor = this.documents.aggregate(aggregationQuery);
     return cursor.toArray();
   }
 
-  async fetchFacets(
-    query: Query,
-    searchProperty: string[] | null,
-    filters: Filter<Document>[]
-  ) {
+  async fetchFacets(query: Query, searchProperty: string[] | null, filters: Filter<Document>[]) {
     const metaAggregationQuery = query.getMetaQuery(searchProperty, this.responseFacets, filters);
     const cursor = this.documents.aggregate(metaAggregationQuery);
     try {

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -59,10 +59,9 @@ export class SearchIndex {
     query: Query,
     searchProperty: string[] | null,
     filters: Filter<Document>[],
-    pageNumber?: number,
-    combineFilters = false
+    pageNumber?: number
   ) {
-    const aggregationQuery = query.getAggregationQuery(searchProperty, filters, pageNumber, combineFilters);
+    const aggregationQuery = query.getAggregationQuery(searchProperty, filters, pageNumber);
     const cursor = this.documents.aggregate(aggregationQuery);
     return cursor.toArray();
   }
@@ -70,10 +69,9 @@ export class SearchIndex {
   async fetchFacets(
     query: Query,
     searchProperty: string[] | null,
-    filters: Filter<Document>[],
-    combineFilters = false
+    filters: Filter<Document>[]
   ) {
-    const metaAggregationQuery = query.getMetaQuery(searchProperty, this.responseFacets, filters, combineFilters);
+    const metaAggregationQuery = query.getMetaQuery(searchProperty, this.responseFacets, filters);
     const cursor = this.documents.aggregate(metaAggregationQuery);
     try {
       // TODO: re-implement


### PR DESCRIPTION
DOP-4089 discussions (on [slack](https://mongodb.slack.com/archives/GGPUBUMLN/p1698844414318519) and [tech spec](https://docs.google.com/document/d/1c9P5_wnlLswoZftJbZG-baqG1Fgs26lO1gv7ExgT3Ss/edit#heading=h.ytznsphw0fe2) included allowing same base level selections as "OR" statements, while treating selections of different base categories as "AND" statements.

This PR aims to do this, by combining query params of the **same base facet**, into a nested compound SHOULD operator, under the root MUST compound operator.

As an example:

Query route:
```
/search/ ?q=$and
&facets.genre=tutorial
&facets.target_product>atlas>sub_product=search
&facets.target_product=drivers
``` 
previously, this translated to MUST statements for each line. and thus, it would return 0 results, since all documents are tagged with either `atlas` or `driver` target product facet, (there is no overlap).
Aggregation translation from above query params:
```
"compound": {
  "must": [
     ....
     {
            "phrase": {
              "query": "tutorial",
              "path": "facets.genre"
            }
      },
     {
            "phrase": {
              "query": "search",
              "path": "facets.target_product>atlas>sub_product"
            }
      },
     {
            "phrase": {
              "query": "drivers",
              "path": "facets.target_product"
            }
      ],
} 
```

This PR translates the same request parameters to the following aggregation:
```
{
  "compound": {
    "must": [
      ...
      {                 <-- compound below translates to "MUST have at least one of these should compounds for genre"
        "compound": {
          "should": [
            { "phrase": { "query": "tutorial", "path": "facets.genre" } }
          ]
        }
      },
      {               <-- compound below translates to "MUST have at least one of these should compounds for target_product"
        "compound": {
          "should": [
            {
              "phrase": {
                "query": "search",
                "path": "facets.target_product>atlas>sub_product"
              }
            },
            {
              "phrase": {
                "query": "drivers",
                "path": "facets.target_product"
              }
            }
          ]
        }
      }
    ]
  }
}
```