### PR TITLE
DOP-4109: Sort facets based on desired UI order

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -290,7 +290,7 @@ export default class Marian {
     }
 
     try {
-      const res = await this.index.fetchFacets(query, searchProperty, filters, combineFilters)
+      const res = await this.index.fetchFacets(query, searchProperty, filters, combineFilters);
       res.facets = sortFacets(res.facets);
       return res;
     } catch (e) {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -12,6 +12,7 @@ import { AtlasAdminManager } from '../AtlasAdmin';
 import { setPropertyMapping } from '../SearchPropertyMapping';
 import { Query, InvalidQuery } from '../Query';
 import { extractFacetFilters } from '../Query/util';
+import { sortFacets } from '../SearchIndex/util';
 
 const STANDARD_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
@@ -289,7 +290,9 @@ export default class Marian {
     }
 
     try {
-      return this.index.fetchFacets(query, searchProperty, filters, combineFilters);
+      const res = await this.index.fetchFacets(query, searchProperty, filters, combineFilters)
+      res.facets = sortFacets(res.facets);
+      return res;
     } catch (e) {
       console.error(`Error fetching facet metadata: ${JSON.stringify(e)}`);
       throw e;

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -234,7 +234,11 @@ const deleteStaleProperties = async (
   status.deleted += deleteResult.deletedCount === undefined ? 0 : deleteResult.deletedCount;
 };
 
-const composeUpserts = (manifest: Manifest, documents: Document[], trieFacets: TrieFacet): AnyBulkWriteOperation<DatabaseDocument>[] => {
+const composeUpserts = (
+  manifest: Manifest,
+  documents: Document[],
+  trieFacets: TrieFacet
+): AnyBulkWriteOperation<DatabaseDocument>[] => {
   return documents.map((document) => {
     assert.strictEqual(typeof document.slug, 'string');
     // DOP-3545 and DOP-3585

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -236,7 +236,7 @@ const deleteStaleProperties = async (
 /**
  * Reorders keys in the facets object. This assumes that all keys are strings that
  * are ordered in insertion order.
- * @param originalFacets 
+ * @param originalFacets
  * @returns A new object for facets, with keys reordered based on intended UI.
  */
 const sortFacetsObject = (originalFacets: Record<string, string[]>) => {
@@ -251,17 +251,20 @@ const sortFacetsObject = (originalFacets: Record<string, string[]>) => {
 
   // Re-convert from array back to object
   const orderedFacets = unorderedFacets.sort(compareFacets);
-  const newFacetsObject: Record<string, string[]> = orderedFacets.reduce((acc: Record<string, string[]>, { key, id }) => {
-    if (!acc[key]) {
-      acc[key] = [];
-    }
-    // Should maintain insertion order of facets array under the same key
-    acc[key].push(id);
-    return acc;
-  }, {});
+  const newFacetsObject: Record<string, string[]> = orderedFacets.reduce(
+    (acc: Record<string, string[]>, { key, id }) => {
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      // Should maintain insertion order of facets array under the same key
+      acc[key].push(id);
+      return acc;
+    },
+    {}
+  );
 
   return newFacetsObject;
-}
+};
 
 const composeUpserts = (manifest: Manifest, documents: Document[]): AnyBulkWriteOperation<DatabaseDocument>[] => {
   return documents.map((document) => {

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -87,13 +87,13 @@ export interface FacetOption extends AmbiguousFacet {
   type: 'facet-option';
   name: string; // used to display for front end
   options: FacetValue[];
-};
+}
 
 export interface FacetValue extends AmbiguousFacet {
   type: 'facet-value';
   name: string;
   count?: number;
   facets: FacetOption[];
-};
+}
 
 export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -81,17 +81,16 @@ export type FacetAggRes = {
 export interface AmbiguousFacet {
   id: string; // used to verify against taxonomy
   key: string;
+  name: string; // used to display for front end
 }
 
 export interface FacetOption extends AmbiguousFacet {
   type: 'facet-option';
-  name: string; // used to display for front end
   options: FacetValue[];
 }
 
 export interface FacetValue extends AmbiguousFacet {
   type: 'facet-value';
-  name: string;
   count?: number;
   facets: FacetOption[];
 }

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -75,19 +75,23 @@ export type FacetAggRes = {
   };
 };
 
-export type FacetOption = {
-  type: 'facet-option';
+/**
+ * Base facet for a FacetOption or FacetValue. Compatible with search documents' facets
+ */
+export interface AmbiguousFacet {
   id: string; // used to verify against taxonomy
-  name: string; // used to display for front end
   key: string;
+}
+
+export interface FacetOption extends AmbiguousFacet {
+  type: 'facet-option';
+  name: string; // used to display for front end
   options: FacetValue[];
 };
 
-export type FacetValue = {
+export interface FacetValue extends AmbiguousFacet {
   type: 'facet-value';
-  id: string;
   name: string;
-  key: string;
   count?: number;
   facets: FacetOption[];
 };

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -6,9 +6,10 @@ import crypto from 'crypto';
 // @ts-ignore
 import dive from 'dive';
 import fs from 'fs';
+import { Document } from 'mongodb';
 import util from 'util';
 
-import { Manifest, Taxonomy, FacetBucket, TrieFacet, FacetAggRes, FacetOption, FacetValue } from './types';
+import { Manifest, Taxonomy, FacetBucket, TrieFacet, FacetAggRes, FacetOption, FacetValue, DatabaseDocument, AmbiguousFacet } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
 
 const log = new Logger({
@@ -186,6 +187,102 @@ export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
   return res;
 }
 
+function getLastKeyPart(key: string) {
+  const parts = key.split('>');
+  return parts[parts.length - 1];
+}
+
+/**
+ * Comparison function that sorts same-level facets based on the following properties:
+ * 1) Facet keys organized by categories/options in the order desired for the UI
+ * 2) Alphabetical ID order (since name might not be guaranteed)
+ * Facets with nested keys will be sorted based on their immediate parent's key 
+ * (i.e. the rightmost part after the last '>')
+ * @param a 
+ * @param b 
+ */
+export function compareFacets(a: AmbiguousFacet, b: AmbiguousFacet): number {
+  // This order is consistent for how options are ordered on the UI
+  const optionsOrder = ['target_product', 'sub_product', 'version', 'programming_language', 'genre'];
+  const optionA = getLastKeyPart(a.key);
+  const optionB = getLastKeyPart(b.key);
+  const indexOfA = optionsOrder.indexOf(optionA);
+  const indexOfB = optionsOrder.indexOf(optionB);
+  const aUndefined = indexOfA === -1;
+  const bUndefined = indexOfB === -1;
+
+  // Options that are defined should be first, followed by any undefined options
+  if (aUndefined && bUndefined) {
+    // Undefined options will be sorted alphabetically by default
+    return optionA.localeCompare(optionB);
+  } else if (bUndefined) {
+    return -1;
+  } else if (aUndefined) {
+    return 1;
+  }
+
+  // Should be negative if indexOfA is less than indexOfB, meaning facet option 
+  // "a" should precede option "b"
+  const res = indexOfA - indexOfB;
+  if (res === 0) {
+    // Alphabetical order may be negligible for parent facets, but not for nested facets
+    return a.id.localeCompare(b.id);
+  }
+
+  return res;
+}
+
+/**
+ * Orders facets at every level from options to values.
+ * @param facets 
+ */
+export function sortFacets(facets: FacetOption[]): FacetOption[] {
+  function compareFacetValues(a: FacetValue, b: FacetValue): number {
+    // Default to sorting alphabetically unless specified
+    return a.name.localeCompare(b.name);
+  }
+
+  function sortValues(facetValues: FacetValue[]) {
+    facetValues.sort(compareFacetValues);
+    facetValues.forEach((facetValue) => {
+      sortOptions(facetValue.facets);
+    });
+  }
+
+  function sortOptions(facetOptions: FacetOption[]) {
+    facetOptions.sort(compareFacets);
+    facetOptions.forEach((facetOption) => {
+      sortValues(facetOption.options);
+    });
+  }
+
+  sortOptions(facets);
+  return facets;
+}
+
+/**
+ * Transforms aggregated search documents with facets to sort their facets based 
+ * on expected order for search results' tags.
+ * @param doc
+ */
+export function sortDocumentFacets(doc: Document) {
+  function sortFacetTags(facets: { id: string, key: string }[]) {
+    // ask what the ideal order is
+  }
+
+  try {
+    if (doc.facets) {
+      doc.facets = (doc.facets);
+    }
+    return doc;
+  } catch (err) {
+    // Mapping functions for MongoDB cursors may not always handle errors as intended,
+    // so we catch here
+    log.error(err);
+    return null;
+  }
+}
+
 /**
  *
  * @param taxonomy    taxonomy representation of all available facets
@@ -232,7 +329,8 @@ export function convertTaxonomyToResponseFormat(taxonomy: Taxonomy): FacetOption
   for (const facetOptionKey of Object.keys(taxonomy)) {
     res.push(constructFacetOption(taxonomy, facetOptionKey, ''));
   }
-  return res;
+
+  return sortFacets(res);
 }
 
 export function joinUrl(base: string, path: string): string {

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -9,7 +9,17 @@ import fs from 'fs';
 import { Document } from 'mongodb';
 import util from 'util';
 
-import { Manifest, Taxonomy, FacetBucket, TrieFacet, FacetAggRes, FacetOption, FacetValue, DatabaseDocument, AmbiguousFacet } from './types';
+import {
+  Manifest,
+  Taxonomy,
+  FacetBucket,
+  TrieFacet,
+  FacetAggRes,
+  FacetOption,
+  FacetValue,
+  DatabaseDocument,
+  AmbiguousFacet,
+} from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
 
 const log = new Logger({
@@ -196,10 +206,10 @@ function getLastKeyPart(key: string) {
  * Comparison function that sorts same-level facets based on the following properties:
  * 1) Facet keys organized by categories/options in the order desired for the UI
  * 2) Alphabetical ID order (since name might not be guaranteed)
- * Facets with nested keys will be sorted based on their immediate parent's key 
+ * Facets with nested keys will be sorted based on their immediate parent's key
  * (i.e. the rightmost part after the last '>')
- * @param a 
- * @param b 
+ * @param a
+ * @param b
  */
 export function compareFacets(a: AmbiguousFacet, b: AmbiguousFacet): number {
   // This order is consistent for how options are ordered on the UI
@@ -221,7 +231,7 @@ export function compareFacets(a: AmbiguousFacet, b: AmbiguousFacet): number {
     return 1;
   }
 
-  // Should be negative if indexOfA is less than indexOfB, meaning facet option 
+  // Should be negative if indexOfA is less than indexOfB, meaning facet option
   // "a" should precede option "b"
   const res = indexOfA - indexOfB;
   if (res === 0) {
@@ -234,7 +244,7 @@ export function compareFacets(a: AmbiguousFacet, b: AmbiguousFacet): number {
 
 /**
  * Orders facets at every level from options to values.
- * @param facets 
+ * @param facets
  */
 export function sortFacets(facets: FacetOption[]): FacetOption[] {
   function getVersionNumber(version: string) {
@@ -307,18 +317,18 @@ export function sortFacets(facets: FacetOption[]): FacetOption[] {
 }
 
 /**
- * Transforms aggregated search documents with facets to sort their facets based 
+ * Transforms aggregated search documents with facets to sort their facets based
  * on expected order for search results' tags.
  * @param doc
  */
 export function sortDocumentFacets(doc: Document) {
-  function sortFacetTags(facets: { id: string, key: string }[]) {
+  function sortFacetTags(facets: { id: string; key: string }[]) {
     // ask what the ideal order is
   }
 
   try {
     if (doc.facets) {
-      doc.facets = (doc.facets);
+      doc.facets = doc.facets;
     }
     return doc;
   } catch (err) {

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -6,7 +6,6 @@ import crypto from 'crypto';
 // @ts-ignore
 import dive from 'dive';
 import fs from 'fs';
-import { Document } from 'mongodb';
 import util from 'util';
 
 import {
@@ -17,7 +16,6 @@ import {
   FacetAggRes,
   FacetOption,
   FacetValue,
-  DatabaseDocument,
   AmbiguousFacet,
 } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
@@ -357,7 +355,7 @@ export function sortFacetsObject(originalFacets: Record<string, string[]>, trieF
       separateFacetsList.push({ id, key, name: getNameFromTrieFacet(trieFacets, key, id) });
     });
   });
-  
+
   separateFacetsList.sort(compareFacets);
   // Re-convert from array back to object
   const newFacetsObject: Record<string, string[]> = separateFacetsList.reduce(
@@ -373,7 +371,7 @@ export function sortFacetsObject(originalFacets: Record<string, string[]>, trieF
   );
 
   return newFacetsObject;
-};
+}
 
 /**
  *

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -33,7 +33,19 @@ describe('Synchronization', function () {
   });
 
   const loadInitialState = async () => {
-    await index.load({} as Taxonomy, PATH_STATE_1);
+    const taxonomy = {
+      genre: [
+        { name: 'reference' },
+        { name: 'tutorial' },
+      ],
+      target_product: [
+        { name: 'docs', display_name: 'Server' },
+      ],
+      programming_language: [
+        { name: 'java' },
+      ],
+    };
+    await index.load(taxonomy, PATH_STATE_1);
     const documentsCursor = client.db(DB).collection<DatabaseDocument>('documents');
     const documents = await documentsCursor.find().toArray();
     sortDocuments(documents);
@@ -55,7 +67,10 @@ describe('Synchronization', function () {
     const documentWithFacet = await documentsCursor.findOne({ facets: { $exists: true } });
     notEqual(documentWithFacet, null);
     if (documentWithFacet?.facets) {
-      deepStrictEqual(Object.keys(documentWithFacet.facets), ['target_product', 'programming_language', 'genre']);
+      const facets: Record<string, string[]> = documentWithFacet.facets;
+      deepStrictEqual(Object.keys(facets), ['target_product', 'programming_language', 'genre']);
+      // Ensure values are also ordered
+      deepStrictEqual(facets['genre'], ['reference', 'tutorial']);
     }
   };
 

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -34,16 +34,9 @@ describe('Synchronization', function () {
 
   const loadInitialState = async () => {
     const taxonomy = {
-      genre: [
-        { name: 'reference' },
-        { name: 'tutorial' },
-      ],
-      target_product: [
-        { name: 'docs', display_name: 'Server' },
-      ],
-      programming_language: [
-        { name: 'java' },
-      ],
+      genre: [{ name: 'reference' }, { name: 'tutorial' }],
+      target_product: [{ name: 'docs', display_name: 'Server' }],
+      programming_language: [{ name: 'java' }],
     };
     await index.load(taxonomy, PATH_STATE_1);
     const documentsCursor = client.db(DB).collection<DatabaseDocument>('documents');

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual, deepStrictEqual } from 'assert';
+import { strictEqual, deepStrictEqual, notEqual } from 'assert';
 import { MongoClient } from 'mongodb';
 import { SearchIndex } from '../../src/SearchIndex';
 import { DatabaseDocument, Taxonomy } from '../../src/SearchIndex/types';
@@ -50,6 +50,13 @@ describe('Synchronization', function () {
       documents.filter((doc) => doc.searchProperty.includes('manual') && doc.slug === 'tutorial/index.html')[0].title,
       'Create a Task Tracker Ap'
     );
+
+    // facets are present and have intended order
+    const documentWithFacet = await documentsCursor.findOne({ facets: { $exists: true } });
+    notEqual(documentWithFacet, null);
+    if (documentWithFacet?.facets) {
+      deepStrictEqual(Object.keys(documentWithFacet.facets), ['target_product', 'programming_language', 'genre']);
+    }
   };
 
   it('loads initial state', loadInitialState);

--- a/tests/integration/test_data/state-1/manual.json
+++ b/tests/integration/test_data/state-1/manual.json
@@ -20,9 +20,9 @@
                 "https://docs.mongodb.com/realm/get-started/introduction-web/"
             ],
             "facets": {
-                "genre": ["tutorial"],
+                "genre": ["tutorial", "reference"],
                 "programming_language": ["java"],
-                "target_product": ["manual"]
+                "target_product": ["docs"]
             }
         },
         {

--- a/tests/integration/test_data/state-1/manual.json
+++ b/tests/integration/test_data/state-1/manual.json
@@ -20,8 +20,9 @@
                 "https://docs.mongodb.com/realm/get-started/introduction-web/"
             ],
             "facets": {
-                "target_product": ["manual"],
-                "genre": ["tutorial"]
+                "genre": ["tutorial"],
+                "programming_language": ["java"],
+                "target_product": ["manual"]
             }
         },
         {

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -2,7 +2,7 @@ import { FacetOption, Taxonomy } from '../../src/SearchIndex/types';
 
 export const sampleTaxonomy = {
   genres: [{ name: 'reference' }, { name: 'tutorial' }],
-  target_platforms: [
+  target_product: [
     { name: 'atlas', versions: [{ name: 'v1.2' }, { name: 'master' }] },
     {
       name: 'atlas-cli',
@@ -33,6 +33,249 @@ export const sampleTaxonomy = {
 export const sampleFacetOption = [
   {
     type: 'facet-option',
+    id: 'target_product',
+    key: 'target_product',
+    name: 'Target Product',
+    options: [
+      {
+        type: 'facet-value',
+        id: 'atlas',
+        key: 'target_product',
+        name: 'Atlas',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>atlas>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_product>atlas>versions',
+                name: 'master',
+                facets: [],
+              },
+              {
+                type: 'facet-value',
+                id: 'v1.2',
+                key: 'target_product>atlas>versions',
+                name: 'v1.2',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'atlas-cli',
+        key: 'target_product',
+        name: 'Atlas CLI',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>atlas-cli>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_product>atlas-cli>versions',
+                name: 'master',
+                facets: [],
+              },
+              {
+                type: 'facet-value',
+                id: 'v1.2',
+                key: 'target_product>atlas-cli>versions',
+                name: 'v1.2',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'golang',
+        key: 'target_product',
+        name: 'Golang',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>golang>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.7',
+                key: 'target_product>golang>versions',
+                name: 'v1.7',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'java',
+        key: 'target_product',
+        name: 'Java',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>java>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v4.3',
+                key: 'target_product>java>versions',
+                name: 'v4.3',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'manual',
+        key: 'target_product',
+        name: 'Manual',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>manual>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'master',
+                key: 'target_product>manual>versions',
+                name: 'master',
+                facets: [],
+              },
+              {
+                type: 'facet-value',
+                id: 'v1.0',
+                key: 'target_product>manual>versions',
+                name: 'v1.0',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'mongocli',
+        key: 'target_product',
+        name: 'Mongo CLI',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>mongocli>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v1.0',
+                key: 'target_product>mongocli>versions',
+                name: 'v1.0',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'node',
+        key: 'target_product',
+        name: 'Node',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>node>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v4.9',
+                key: 'target_product>node>versions',
+                name: 'v4.9',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'spark-connector',
+        key: 'target_product',
+        name: 'Spark Connector',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>spark-connector>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'v2.1',
+                key: 'target_product>spark-connector>versions',
+                name: 'v2.1',
+                facets: [],
+              },
+              {
+                type: 'facet-value',
+                id: 'v2.0',
+                key: 'target_product>spark-connector>versions',
+                name: 'v2.0',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'facet-value',
+        id: 'visual-studio-extension',
+        key: 'target_product',
+        name: 'Visual Studio Extension',
+        facets: [
+          {
+            type: 'facet-option',
+            id: 'versions',
+            key: 'target_product>visual-studio-extension>versions',
+            name: 'versions',
+            options: [
+              {
+                type: 'facet-value',
+                id: 'current',
+                key: 'target_product>visual-studio-extension>versions',
+                name: 'current',
+                facets: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'facet-option',
     id: 'genres',
     key: 'genres',
     name: 'Genres',
@@ -50,249 +293,6 @@ export const sampleFacetOption = [
         key: 'genres',
         name: 'Tutorial',
         facets: [],
-      },
-    ],
-  },
-  {
-    type: 'facet-option',
-    id: 'target_platforms',
-    key: 'target_platforms',
-    name: 'Target Platforms',
-    options: [
-      {
-        type: 'facet-value',
-        id: 'atlas',
-        key: 'target_platforms',
-        name: 'Atlas',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>atlas>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v1.2',
-                key: 'target_platforms>atlas>versions',
-                name: 'v1.2',
-                facets: [],
-              },
-              {
-                type: 'facet-value',
-                id: 'master',
-                key: 'target_platforms>atlas>versions',
-                name: 'master',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'atlas-cli',
-        key: 'target_platforms',
-        name: 'Atlas CLI',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>atlas-cli>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v1.2',
-                key: 'target_platforms>atlas-cli>versions',
-                name: 'v1.2',
-                facets: [],
-              },
-              {
-                type: 'facet-value',
-                id: 'master',
-                key: 'target_platforms>atlas-cli>versions',
-                name: 'master',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'manual',
-        key: 'target_platforms',
-        name: 'Manual',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>manual>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v1.0',
-                key: 'target_platforms>manual>versions',
-                name: 'v1.0',
-                facets: [],
-              },
-              {
-                type: 'facet-value',
-                id: 'master',
-                key: 'target_platforms>manual>versions',
-                name: 'master',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'spark-connector',
-        key: 'target_platforms',
-        name: 'Spark Connector',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>spark-connector>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v2.0',
-                key: 'target_platforms>spark-connector>versions',
-                name: 'v2.0',
-                facets: [],
-              },
-              {
-                type: 'facet-value',
-                id: 'v2.1',
-                key: 'target_platforms>spark-connector>versions',
-                name: 'v2.1',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'node',
-        key: 'target_platforms',
-        name: 'Node',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>node>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v4.9',
-                key: 'target_platforms>node>versions',
-                name: 'v4.9',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'mongocli',
-        key: 'target_platforms',
-        name: 'Mongo CLI',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>mongocli>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v1.0',
-                key: 'target_platforms>mongocli>versions',
-                name: 'v1.0',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'visual-studio-extension',
-        key: 'target_platforms',
-        name: 'Visual Studio Extension',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>visual-studio-extension>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'current',
-                key: 'target_platforms>visual-studio-extension>versions',
-                name: 'current',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'golang',
-        key: 'target_platforms',
-        name: 'Golang',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>golang>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v1.7',
-                key: 'target_platforms>golang>versions',
-                name: 'v1.7',
-                facets: [],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'facet-value',
-        id: 'java',
-        key: 'target_platforms',
-        name: 'Java',
-        facets: [
-          {
-            type: 'facet-option',
-            id: 'versions',
-            key: 'target_platforms>java>versions',
-            name: 'versions',
-            options: [
-              {
-                type: 'facet-value',
-                id: 'v4.3',
-                key: 'target_platforms>java>versions',
-                name: 'v4.3',
-                facets: [],
-              },
-            ],
-          },
-        ],
       },
     ],
   },


### PR DESCRIPTION
### Ticket

DOP-4109

### Notes

* Facets are generally ordered based on the following:
  1) Facet option/category
  2) Alphabetical order
* Facets with versions are ordered similarly to how the frontend currently does: from descending order, with "upcoming" or "latest" above "current" or "stable".
* Facets are ordered in a few places:
   1) When creating the structured taxonomy response after index creation. This is the same object returned by `/v2/status`.
   2) When upserting documents based on the manifest. This is to avoid needing to sort facets for every individual search result for every single search.
   3) Whenever `/v2/search/meta?q=<query>` is called. This is sorted for every request/response. I'm unsure if there's a way to sort only once and forget it since it seems like facets are aggregated per request.
* Please see tests for general expectations on sorting order. Also see screenshots for before and afters (in case data or search indexes are changed from other ongoing search work).

### Screenshots

Context | Before | After
:-----------:|:--------------:|:-------------------------:
Search documents | ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/c4d0b9ec-c7c6-4cda-a11f-8547ae955db0)  |  ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/011a812c-ad7b-4f56-94ae-5e569db9c097)
Search results | ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/c2704815-9159-4aae-8a69-5f8d6c5bca35) | ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/61ef92fc-7fe5-4338-9260-3027a83651ed)
Search meta results | ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/dd54dd52-c59d-4e69-9356-28a4f3e9c266) | ![image](https://github.com/mongodb/docs-search-transport/assets/27821750/44ccb18e-ac48-4246-acd7-a390c4c48c77)





