### PR TITLE
DOP-3998: allow CORS authentication

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3998'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3998'
 
 steps:
   - name: publish-staging

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -21,7 +21,7 @@ const STANDARD_HEADERS = {
   // allow CORS via credentials
   // https://kanopy.corp.mongodb.com/docs/security/corpsecure/#cors-simple-request-example
   'access-control-allow-credentials': true,
-  'access-control-allow-methods': 'GET'
+  'access-control-allow-methods': 'GET',
 };
 
 const log = new Logger({

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -17,6 +17,11 @@ import { sortFacets } from '../SearchIndex/util';
 const STANDARD_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'deny',
+
+  // allow CORS via credentials
+  // https://kanopy.corp.mongodb.com/docs/security/corpsecure/#cors-simple-request-example
+  'access-control-allow-credentials': true,
+  'access-control-allow-methods': 'GET'
 };
 
 const log = new Logger({


### PR DESCRIPTION
DOP-3998

as per[ Kanopy documentation ](https://kanopy.corp.mongodb.com/docs/security/corpsecure/#cors-simple-requests)on CORS policies, this change allows server to accept credentials

tested with this [staged change](https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/DOP-3998-2/search/?q=atlas&page=1).

Above staged site makes requests to `https://docs-search-transport.docs.staging.corp.mongodb.com` while sending user credentials via `request.header.cookies` (this is obtained via okta auth) to authenticate with server to bypass CORS issues