### PR TITLE
DOP-4121: Boost/bury based on product usage & pageviews

### DIFF
--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -4,20 +4,20 @@ import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
 
-export class InvalidQuery extends Error { }
+export class InvalidQuery extends Error {}
 
 function processPart(part: string): string[] {
   return tokenize(part, false);
 }
 
-const BURIED_PROPERTIES= ['realm'];
+const BURIED_PROPERTIES = ['realm'];
 const BURIED_FACTOR = 0.8;
 
 //check type of parts
 function constructAgg(parts: any[]): object[] {
   const newParts: any[] = [];
   for (var part of parts) {
-    //push to two compounds for each part to the new array 
+    //push to two compounds for each part to the new array
     newParts.push(
       //if given query matches a "part" result not in BURIED_PROPERTY(ex: Realm) docs, score remains unaffected
       {
@@ -27,11 +27,11 @@ function constructAgg(parts: any[]): object[] {
             {
               text: {
                 query: BURIED_PROPERTIES,
-                path: 'searchProperty'
-              }
-            }
-          ]
-        }
+                path: 'searchProperty',
+              },
+            },
+          ],
+        },
       },
       //if given query matches a "part" result in BURIED_PROPERTY(ex: Realm) docs, bury that result
       {
@@ -42,11 +42,11 @@ function constructAgg(parts: any[]): object[] {
               text: {
                 query: BURIED_PROPERTIES,
                 path: 'searchProperty',
-              }
-            }
+              },
+            },
           ],
-          score: { "boost": { value: BURIED_FACTOR } },
-        }
+          score: { boost: { value: BURIED_FACTOR } },
+        },
       }
     );
   }

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -12,16 +12,17 @@ function processPart(part: string): string[] {
 
 //check type of parts
 function constructAgg(parts: any[]): object[] {
-  console.log("THE PARTS", parts);
   const newParts: any[] = [];
   for(var part of parts){ 
-    newParts.push({ compound: {
+    //push to the two compounds for each part to the new
+    newParts.push(
+      { compound: {
       must: [part],
       mustNot: [
         {
           text: {
-            query: 'Realm',
-            path: ['searchProperty']
+            query: 'realm-master',
+            path: 'searchProperty'
           }
         }
       ]
@@ -33,17 +34,16 @@ function constructAgg(parts: any[]): object[] {
         part,
         {
           text:{
-            query: 'Realm',
-            path: ['searchProperty']
+            query: 'realm-master',
+            path: 'searchProperty'
           }
         }
       ],
-      score: {"boost": {value: 0.5}}
+       score: {"boost": {value: 0.8}}
      } 
-    });
-    //push to the two compounds as one should clause to the array
+    }
+    );
   }
-  console.log(newParts[0].compound, newParts[0].compound.mustNot, newParts[0].compound.must[0]);
   return newParts;
 }
 
@@ -228,7 +228,6 @@ export class Query {
       // each compound (as a whole) must be matched
       compound.must = compound.must.concat(filters);
     }
-    console.log("COMPOUND", compound);
     return compound;
   }
 
@@ -248,7 +247,7 @@ export class Query {
       },
     ];
 
-    console.log('Executing ' + JSON.stringify(agg));
+    console.log('Executing ' + JSON.stringify(agg) );
     return agg;
   }
 

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -13,8 +13,8 @@ function processPart(part: string): string[] {
 const BURIED_PROPERTIES = ['realm'];
 const BURIED_FACTOR = 0.8;
 
-//check type of parts
-function constructAgg(parts: any[]): object[] {
+// each $search operator is expanded into two compound operators so that certain properties are buried
+function constructBuryOperators(parts: any[]): object[] {
   const newParts: any[] = [];
   for (const part of parts) {
     //push to two compounds for each part to the new array
@@ -180,8 +180,7 @@ export class Query {
     });
 
     const compound: { should: any[]; must: any[]; filter?: any[]; minimumShouldMatch: number } = {
-      //each of the "text" elements of push need to be put inside another compound:{must[ and duplicated, one with realm and one without
-      should: constructAgg(parts),
+      should: constructBuryOperators(parts),
       minimumShouldMatch: 1,
       must: [],
     };

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -16,7 +16,7 @@ const BURIED_FACTOR = 0.8;
 //check type of parts
 function constructAgg(parts: any[]): object[] {
   const newParts: any[] = [];
-  for (var part of parts) {
+  for (const part of parts) {
     //push to two compounds for each part to the new array
     newParts.push(
       //if given query matches a "part" result not in BURIED_PROPERTY(ex: Realm) docs, score remains unaffected


### PR DESCRIPTION
### Ticket
[DOP-4121](https://jira.mongodb.org/browse/DOP-4121)

### Context
Realm docs are currently overrepresented in search result sets by a slight margin. This PR buries results with the `searchProperty` `realm-master` but keeps all other results, as well as their order, identical. The approach used was the suggested one for burying/boosting certain results as detailed [here](https://docs.google.com/document/d/1G1RYHBbFXqm5kG98GETCTvKj1UJHv5rzDHG18X-5jYM/edit#heading=h.sq6vzuky8sas)



## NOTES

- Testing: Only a limited amount of testing could be done. To test, query results from the local staging instance were compared with the results of the same queries on the staging server. 
Ex: https://docs-search-transport.docs.staging.corp.mongodb.com/search/?q=sdk compared to http://localhost:8080/search/?q=sdk. Several queries were tested, and the behavioral outcomes seemed to be as desired. Queries that do not yield any 'Realm docs' results on the staging server yielded the the same results in the same order on the local staging instance.  Queries that do yield some 'Realm docs' results on the staging server yielded results that were identical except for that docs with 'Realm-master' search property were lower down (buried) in the search results. However, it should be noted that it was not possible to check the score of any of the result documents and so it couldn't be verified whether they were buried exactly, and only, to the desired extent.

- "`Any`" typing is frequent in `Query/index.ts`
- The ticket asks if we should always bury, e.g. will there be realm-specific search terms that we should ignore? This has not been discussed further
