### PR TITLE
DOP-4145: Add context to Docs Search Transport errors

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -64,10 +64,10 @@ export default class Marian {
     try {
       parsedUrl = new URL(url, `http://${req.headers?.host}`);
     } catch (e) {
-log.warn(`URL constructor could not create a URL with url ${url} and base ${req.headers?.host}`);
-res.writeHead(500, {});
-res.end('');
-return;
+      log.warn(`URL constructor could not create a URL with url ${url} and base ${req.headers?.host}`);
+      res.writeHead(500, {});
+      res.end('');
+      return;
     }
     const pathname = (parsedUrl.pathname || '').replace(/\/+$/, '');
     if (pathname === '/search') {
@@ -265,7 +265,7 @@ return;
       const toml = await res.text();
       return parse(toml);
     } catch (e) {
-      console.error(`Error while fetching taxonomy: ${JSON.stringify(e)}`);
+      log.error(`Error while fetching taxonomy: ${JSON.stringify(e)}`);
       throw e;
     }
   }
@@ -301,7 +301,7 @@ return;
       res.facets = sortFacets(res.facets);
       return res;
     } catch (e) {
-      console.error(
+      log.error(
         `Error fetching facet metadata for query ${rawQuery}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
           e
         )}`

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -63,8 +63,7 @@ export default class Marian {
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(url, `http://${req.headers?.host}`);
-    }
-    catch (e){
+    } catch (e) {
       console.error(`URL constructor could not create a URL with url ${url} and base ${req.headers?.host}`);
       console.trace();
       throw e;
@@ -297,26 +296,32 @@ export default class Marian {
     if (typeof searchProperty === 'string') {
       searchProperty = [searchProperty];
     }
-  
+
     let res: {
       count: number;
       facets: any[];
-    
-    }
+    };
     try {
       res = await this.index.fetchFacets(query, searchProperty, filters);
     } catch (e) {
-      console.error(`Error fetching facet metadata for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(e)} `);
-      console.trace()
+      console.error(
+        `Error fetching facet metadata for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
+          e
+        )} `
+      );
+      console.trace();
       throw e;
     }
     try {
       res.facets = sortFacets(res.facets);
       return res;
-    }
-    catch(e){
-      console.error(`Error sorting metadata facets for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(e)}`);
-      console.trace()
+    } catch (e) {
+      console.error(
+        `Error sorting metadata facets for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
+          e
+        )}`
+      );
+      console.trace();
       throw e;
     }
   }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -251,7 +251,6 @@ export default class Marian {
     if (typeof searchProperty === 'string') {
       searchProperty = [searchProperty];
     }
-
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
     return this.index.search(query, searchProperty, filters, pageNumber);
   }
@@ -296,28 +295,13 @@ export default class Marian {
     if (typeof searchProperty === 'string') {
       searchProperty = [searchProperty];
     }
-
-    let res: {
-      count: number;
-      facets: any[];
-    };
     try {
-      res = await this.index.fetchFacets(query, searchProperty, filters);
-    } catch (e) {
-      console.error(
-        `Error fetching facet metadata for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
-          e
-        )} `
-      );
-      console.trace();
-      throw e;
-    }
-    try {
+      const res = await this.index.fetchFacets(query, searchProperty, filters);
       res.facets = sortFacets(res.facets);
       return res;
     } catch (e) {
       console.error(
-        `Error sorting metadata facets for query ${query}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
+        `Error fetching facet metadata for query ${rawQuery}, with search property ${searchProperty}, and filters ${filters}. ${JSON.stringify(
           e
         )}`
       );

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -64,9 +64,10 @@ export default class Marian {
     try {
       parsedUrl = new URL(url, `http://${req.headers?.host}`);
     } catch (e) {
-      console.error(`URL constructor could not create a URL with url ${url} and base ${req.headers?.host}`);
-      console.trace();
-      throw e;
+log.warn(`URL constructor could not create a URL with url ${url} and base ${req.headers?.host}`);
+res.writeHead(500, {});
+res.end('');
+return;
     }
     const pathname = (parsedUrl.pathname || '').replace(/\/+$/, '');
     if (pathname === '/search') {

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -72,7 +72,8 @@ export class SearchIndex {
       const aggRes = await cursor.toArray();
       return formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.trieFacets);
     } catch (e) {
-      log.error(`Error while fetching facets: ${JSON.stringify(e)}`);
+      log.error(`Error while fetching facets for query ${query}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(e)}`);
+      log.trace();
       throw e;
     }
   }
@@ -80,7 +81,6 @@ export class SearchIndex {
   async load(taxonomy: Taxonomy, manifestSource?: string, refreshManifests = true): Promise<RefreshInfo | undefined> {
     this.responseFacets = convertTaxonomyToResponseFormat(taxonomy);
     this.trieFacets = convertTaxonomyToTrie(taxonomy);
-
     if (!refreshManifests) {
       return;
     }

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -73,9 +73,9 @@ export class SearchIndex {
       return formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.trieFacets);
     } catch (e) {
       log.error(
-        `Error while fetching facets for query ${query.rawQuery}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(
-          e
-        )}`
+        `Error while fetching facets for query ${
+          query.rawQuery
+        }, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(e)}`
       );
       log.trace();
       throw e;

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -73,7 +73,7 @@ export class SearchIndex {
       return formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.trieFacets);
     } catch (e) {
       log.error(
-        `Error while fetching facets for query ${query}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(
+        `Error while fetching facets for query ${query.rawQuery}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(
           e
         )}`
       );

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -72,7 +72,11 @@ export class SearchIndex {
       const aggRes = await cursor.toArray();
       return formatFacetMetaResponse(aggRes[0] as FacetAggRes, this.trieFacets);
     } catch (e) {
-      log.error(`Error while fetching facets for query ${query}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(e)}`);
+      log.error(
+        `Error while fetching facets for query ${query}, with search property ${searchProperty}, and filters ${filters} ${JSON.stringify(
+          e
+        )}`
+      );
       log.trace();
       throw e;
     }


### PR DESCRIPTION
### Ticket
[DOP-4145](https://jira.mongodb.org/browse/DOP-4145)

### Currrent Behavior
Docs Search Transport [Splunk logs](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22docs-prod%22%20%20source%3D%22*search-transport*%22%20%5C(error%5C)&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1700024400&latest=1700715600&sid=1700685979.1211656) show several errors. The two that are the focus of this ticket are URL Type Errors and facet fetching errors. Examples of each are included below
![Screenshot 2023-11-30 at 2 04 02 PM](https://github.com/mongodb/docs-search-transport/assets/41971124/86cf4ad8-545e-43ed-b2ea-fc5d9a99bd99)
![Screenshot 2023-11-30 at 2 06 29 PM](https://github.com/mongodb/docs-search-transport/assets/41971124/12785fa0-8131-4615-8e28-18ab8f2a4b5e)

Error handling and logging of such errors is now improved to provide greater context for debugging purposes
