### PR TITLE
DOP-4182: Specify types for query builder in search transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Available query parameters:
 - (required) `q` - string to be queried (e.g. `findbyidandupdate`)
 - (optional) `searchProperty` - which docs property the query should be refined by (e.g. `manual`)
 - (optional) `page` - which page of results to display (e.g. `2`)
-- (optional) `facets` - a list of selected facets/subfacets in the format `target_product>product>subproduct`
+- (optional) `facets.target_product>product>subproduct` or `facets.target_product` - a list of selected facets/subfacets
+
+A request might look like `https://localhost:8080/search?q=hello&page=2&facets.target_product>atlas>sub_product=search&facets.target_product=atlas`.
 
 A node debugger (ie. [chrome developer tools](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients)) can be connected to the built JS files.
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Available query parameters:
 - (required) `q` - string to be queried (e.g. `findbyidandupdate`)
 - (optional) `searchProperty` - which docs property the query should be refined by (e.g. `manual`)
 - (optional) `page` - which page of results to display (e.g. `2`)
-- (optional) `facets.target_product>product>subproduct` or `facets.target_product` - a list of selected facets/subfacets
+- (optional) `facets.target_product>product>sub_product` or `facets.target_product` - a list of selected facets/subfacets
 
-A request might look like `https://localhost:8080/search?q=hello&page=2&facets.target_product>atlas>sub_product=search&facets.target_product=atlas`.
+A request might look like `http://localhost:8080/search/?q=filter&facets.target_product=atlas&facets.target_product>atlas>sub_product=atlas-app-services`.
 
 A node debugger (ie. [chrome developer tools](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients)) can be connected to the built JS files.
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -3,11 +3,12 @@ import assert from 'assert';
 import Logger from 'basic-logger';
 import http from 'http';
 import { parse } from 'toml';
+import { Document } from 'mongodb';
 
 import { checkAllowedOrigin, checkMethod } from './util';
 import { StatusResponse } from './types';
 import { SearchIndex } from '../SearchIndex';
-import { Taxonomy } from '../SearchIndex/types';
+import { FacetMeta, Taxonomy } from '../SearchIndex/types';
 import { AtlasAdminManager } from '../AtlasAdmin';
 import { setPropertyMapping } from '../SearchPropertyMapping';
 import { Query, InvalidQuery } from '../Query';
@@ -233,7 +234,7 @@ export default class Marian {
     res.end(responseBody);
   }
 
-  private async fetchResults(parsedUrl: URL): Promise<any[]> {
+  private async fetchResults(parsedUrl: URL): Promise<Document[]> {
     const rawQuery = (parsedUrl.searchParams.get('q') || '').toString();
 
     if (!rawQuery) {
@@ -283,7 +284,7 @@ export default class Marian {
     res.end(responseBody);
   }
 
-  private async fetchFacetMeta(parsedUrl: URL): Promise<any> {
+  private async fetchFacetMeta(parsedUrl: URL): Promise<FacetMeta> {
     const rawQuery = (parsedUrl.searchParams.get('q') || '').toString();
     if (!rawQuery || !rawQuery.length) {
       throw new InvalidQuery();

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,4 +1,4 @@
-import { Filter } from 'mongodb';
+import { Filter, Document as mdbDocument } from 'mongodb';
 import { getFacetAggregationStages, getProjectionAndFormatStages, tokenize } from './util';
 import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
@@ -103,7 +103,7 @@ export class Query {
     }
   }
 
-  getCompound(searchProperty: string[] | null, filters: Filter<Document>[]) {
+  getCompound(searchProperty: string[] | null, filters: Filter<Document>[]): Compound {
     const terms = Array.from(this.terms);
     const parts: Part[] = [];
     const searchPropertyMapping = getPropertyMapping();
@@ -237,8 +237,8 @@ export class Query {
     return compound;
   }
 
-  getMetaQuery(searchProperty: string[] | null, taxonomy: FacetOption[], filters: Filter<Document>[]) {
-    const compound = this.getCompound(searchProperty, filters);
+  getMetaQuery(searchProperty: string[] | null, taxonomy: FacetOption[], filters: Filter<Document>[]): mdbDocument[] {
+    const compound: Compound = this.getCompound(searchProperty, filters);
 
     const facets = getFacetAggregationStages(taxonomy);
 
@@ -257,13 +257,13 @@ export class Query {
     return agg;
   }
 
-  getAggregationQuery(searchProperty: string[] | null, filters: Filter<Document>[], page?: number): Filter<Document>[] {
+  getAggregationQuery(searchProperty: string[] | null, filters: Filter<Document>[], page?: number): mdbDocument[] {
     if (page && page < 1) {
       throw new InvalidQuery('Invalid page');
     }
     const compound = this.getCompound(searchProperty, filters);
 
-    const agg: Filter<Document>[] = [
+    const agg: mdbDocument[] = [
       {
         $search: {
           compound,

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -3,7 +3,7 @@ import { getFacetAggregationStages, getProjectionAndFormatStages, tokenize } fro
 import { Document, FacetOption } from '../SearchIndex/types';
 import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
-import { Part, CompoundPart, Must } from './types';
+import { Part, CompoundPart, Compound } from './types';
 
 export class InvalidQuery extends Error {}
 
@@ -180,7 +180,7 @@ export class Query {
       },
     });
 
-    const compound: { should: CompoundPart[]; must: Must[]; filter?: any[]; minimumShouldMatch: number } = {
+    const compound: Compound = {
       should: constructBuryOperators(parts),
       minimumShouldMatch: 1,
       must: [],

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -1,0 +1,48 @@
+import { Filter } from 'mongodb';
+import { Document } from '../SearchIndex/types';
+
+type PathObj = {
+  value: string;
+  multi: string;
+};
+
+type Path = string | PathObj;
+
+export type Score = {
+  boost: {
+    value: number;
+  };
+};
+
+export type Part = {
+  text: {
+    path: Path | Path[];
+    query: string[];
+    score?: Score;
+    synonyms?: string;
+  };
+};
+
+export type CompoundPart = {
+  compound: {
+    must: Part[];
+    mustNot?: Part[];
+    score?: Score;
+  };
+};
+
+type Phrase = {
+  phrase: {
+    path: string | string[];
+    query: string | string[];
+  };
+};
+
+type Equals = {
+  equals: {
+    path: string | string[];
+    value: boolean;
+  };
+};
+
+export type Must = Phrase | Equals | Filter<Document>;

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -1,5 +1,4 @@
-import { Filter } from 'mongodb';
-import { Document } from '../SearchIndex/types';
+import { Document } from 'mongodb';
 
 type PathObj = {
   value: string;
@@ -45,7 +44,7 @@ type Equals = {
   };
 };
 
-type Must = Phrase | Equals | Filter<Document>;
+type Must = Phrase | Equals | Document;
 
 export type Compound = {
   should: CompoundPart[];

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -45,4 +45,10 @@ type Equals = {
   };
 };
 
-export type Must = Phrase | Equals | Filter<Document>;
+type Must = Phrase | Equals | Filter<Document>;
+
+export type Compound = {
+  should: CompoundPart[];
+  must: Must[];
+  minimumShouldMatch: number;
+};

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -101,3 +101,5 @@ export interface FacetValue extends AmbiguousFacet {
 }
 
 export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };
+
+export type RefObj = { [key: string]: { name: string } } | Record<string, any> | TrieFacet;

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -75,6 +75,11 @@ export type FacetAggRes = {
   };
 };
 
+export type FacetMeta = {
+  count: number;
+  facets: FacetOption[];
+};
+
 /**
  * Base facet for a FacetOption or FacetValue. Compatible with search documents' facets
  */

--- a/src/SearchIndex/types.ts
+++ b/src/SearchIndex/types.ts
@@ -101,5 +101,3 @@ export interface FacetValue extends AmbiguousFacet {
 }
 
 export type FacetAggregationStage = { [key: string]: { type: 'string'; path: string } };
-
-export type RefObj = { [key: string]: { name: string } } | Record<string, any> | TrieFacet;

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -16,6 +16,7 @@ import {
   FacetAggRes,
   FacetOption,
   FacetValue,
+  FacetMeta,
   AmbiguousFacet,
 } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
@@ -35,10 +36,10 @@ function convertTitleCase(name: string, property: string): string {
   return name.replace(/^[_-]*(.)|[_-]+(.)/g, (s, c, d) => (c ? c.toUpperCase() : ' ' + d.toUpperCase()));
 }
 
-export function formatFacetMetaResponse(facetAggRes: FacetAggRes, taxonomyTrie: TrieFacet) {
+export function formatFacetMetaResponse(facetAggRes: FacetAggRes, taxonomyTrie: TrieFacet): FacetMeta {
   const facets: FacetOption[] = convertToFacetOptions(facetAggRes.facet, taxonomyTrie);
 
-  return {
+  return <FacetMeta>{
     count: facetAggRes.count['lowerBound'],
     facets: facets,
   };
@@ -167,6 +168,7 @@ export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
     name: '',
   };
 
+  // TODO: any
   function addToRes(entityList: TaxonomyEntity[], ref: { [key: string]: any }, property: string) {
     ref[property] = {
       name: convertTitleCase(property, property), // convert snakecase to title case

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -18,7 +18,6 @@ import {
   FacetValue,
   FacetMeta,
   AmbiguousFacet,
-  RefObj,
 } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
 

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -18,6 +18,7 @@ import {
   FacetValue,
   FacetMeta,
   AmbiguousFacet,
+  RefObj,
 } from './types';
 import { TaxonomyEntity } from '../SearchIndex/types';
 
@@ -168,8 +169,7 @@ export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
     name: '',
   };
 
-  // TODO: any
-  function addToRes(entityList: TaxonomyEntity[], ref: { [key: string]: any }, property: string) {
+  function addToRes(entityList: TaxonomyEntity[], ref: RefObj, property: string) {
     ref[property] = {
       name: convertTitleCase(property, property), // convert snakecase to title case
     };

--- a/src/SearchIndex/util.ts
+++ b/src/SearchIndex/util.ts
@@ -169,13 +169,13 @@ export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
     name: '',
   };
 
-  function addToRes(entityList: TaxonomyEntity[], ref: RefObj, property: string) {
+  function addToRes(entityList: TaxonomyEntity[], ref: TrieFacet, property: string) {
     ref[property] = {
       name: convertTitleCase(property, property), // convert snakecase to title case
     };
-    ref = ref[property];
+    ref = ref[property] as TrieFacet;
     for (const taxEntity of entityList) {
-      const entity: Record<string, any> = {
+      const entity: TrieFacet = {
         name: taxEntity['display_name'] || convertTitleCase(taxEntity['name'], property),
       };
       if (property === 'versions' && taxEntity['stable']) {
@@ -195,7 +195,7 @@ export function convertTaxonomyToTrie(taxonomy: Taxonomy): TrieFacet {
     if (stringKey === 'name') {
       continue;
     }
-    addToRes(taxonomy[stringKey], res as object, stringKey);
+    addToRes(taxonomy[stringKey], res, stringKey);
   }
   return res;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const DEFAULT_DATABASE_NAME = 'search';
 const GROUP_KEY = 'GROUP_ID';
 const ADMIN_API_KEY = 'ATLAS_ADMIN_API_KEY';
 const ADMIN_PUB_KEY = 'ATLAS_ADMIN_PUB_KEY';
+const TAXONOMY_URL = 'TAXONOMY_URL';
 
 function help(): void {
   console.error(`Usage: search-transport [--create-indexes] [--load-manifests]
@@ -33,6 +34,7 @@ The following environment variables are used:
 * ${GROUP_KEY}
 * ${ADMIN_API_KEY}
 * ${ADMIN_PUB_KEY}
+* ${TAXONOMY_URL}
 `);
 }
 
@@ -42,6 +44,7 @@ function verifyAndGetEnvVars() {
   const groupId = process.env[GROUP_KEY];
   const adminPubKey = process.env[ADMIN_PUB_KEY];
   const adminPrivKey = process.env[ADMIN_API_KEY];
+  const taxonomyUrl = process.env[TAXONOMY_URL];
 
   if (!manifestUri || !atlasUri || !groupId || !adminPrivKey || !adminPubKey) {
     if (!manifestUri) {
@@ -59,7 +62,9 @@ function verifyAndGetEnvVars() {
     if (!adminPubKey) {
       console.error(`Missing ${ADMIN_PUB_KEY}`);
     }
-    // TODO: add taxonomy url
+    if (!taxonomyUrl) {
+      console.error(`Missing ${TAXONOMY_URL}`);
+    }
     help();
     process.exit(1);
   }


### PR DESCRIPTION
### Ticket

DOP-4182

### Notes

I tried to update `any` types when it seemed pretty straightforward. Here are some places where I did not change types (as well as left a couple other comments detailing reasoning):
- [src/data/atlas-types.ts](https://github.com/mongodb/docs-search-transport/blob/main/src/data/atlas-types.ts#L9) - I couldn't really easily find enough information on the returned `SearchIndexResponse` to know what types should exist in `customAnalyzer`. 
- [src/Marian/index.ts](https://github.com/mongodb/docs-search-transport/blob/main/src/Marian/index.ts#L135) - don't feel it's necessary to type the error
- [src/SearchIndex/util.ts](https://github.com/mongodb/docs-search-transport/blob/main/src/SearchIndex/util.ts#L176) - not sure what the `any` in `Record<string,any>` would look like, figured at least the typing added will suffice

This PR also updates the README with some testing info, as well as adds checks for the `TAXONOMY_URL` environment variable.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
