### PR TITLE
DOP-3976: add a boost for phrase of the original query

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-3976'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-3976'
 
 steps:
   - name: publish-staging

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -195,7 +195,7 @@ export class Query {
           query: terms.join(' '),
           score: {
             boost: {
-              value: 50,
+              value: 10,
             },
           },
         },

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -187,6 +187,19 @@ export class Query {
     };
     const searchPropertyNames = Object.keys(searchPropertyMapping);
 
+    // DOP-3976: phrases found in conjunction should have additional score boost
+    compound.should.push({
+      phrase: {
+        path: ['paragraphs', 'text', 'headings'],
+        query: terms.join(' '),
+        score: {
+          boost: {
+            value: 50,
+          },
+        },
+      },
+    });
+
     // if user requested searchProperty, must match this property name
     // allowing mix usage of searchProperty and facets
     if (searchProperty !== null && searchProperty.length !== 0) {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -189,13 +189,15 @@ export class Query {
 
     // DOP-3976: phrases found in conjunction should have additional score boost if they are found in order
     if (terms.length > 1) {
+      const maxLength: number = terms.reduce((max, term) => Math.max(max, term.length), 0);
       compound.should.push({
         phrase: {
           path: ['paragraphs', 'text', 'headings'],
           query: terms.join(' '),
+          slop: maxLength,
           score: {
             boost: {
-              value: 10,
+              value: 15,
             },
           },
         },

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -197,7 +197,7 @@ export class Query {
           slop: maxLength,
           score: {
             boost: {
-              value: 15,
+              value: 25,
             },
           },
         },

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -187,18 +187,20 @@ export class Query {
     };
     const searchPropertyNames = Object.keys(searchPropertyMapping);
 
-    // DOP-3976: phrases found in conjunction should have additional score boost
-    compound.should.push({
-      phrase: {
-        path: ['paragraphs', 'text', 'headings'],
-        query: terms.join(' '),
-        score: {
-          boost: {
-            value: 50,
+    // DOP-3976: phrases found in conjunction should have additional score boost if they are found in order
+    if (terms.length > 1) {
+      compound.should.push({
+        phrase: {
+          path: ['paragraphs', 'text', 'headings'],
+          query: terms.join(' '),
+          score: {
+            boost: {
+              value: 50,
+            },
           },
         },
-      },
-    });
+      });
+    }
 
     // if user requested searchProperty, must match this property name
     // allowing mix usage of searchProperty and facets

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -197,6 +197,18 @@ export class Query {
           slop: maxLength,
           score: {
             boost: {
+              value: 5,
+            },
+          },
+        },
+      });
+
+      compound.should.push({
+        phrase: {
+          path: ['paragraphs', 'text', 'headings'],
+          query: terms.join(' '),
+          score: {
+            boost: {
               value: 25,
             },
           },

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -22,18 +22,23 @@ export type Part = {
   };
 };
 
-export type CompoundPart = {
-  compound: {
-    must: Part[];
-    mustNot?: Part[];
-    score?: Score;
-  };
-};
+export type CompoundPart =
+  | Part
+  | Phrase
+  | {
+      compound: {
+        must: Part[];
+        mustNot?: Part[];
+        score?: Score;
+      };
+    };
 
-type Phrase = {
+export type Phrase = {
   phrase: {
     path: string | string[];
     query: string | string[];
+    slop?: number;
+    score?: Score;
   };
 };
 

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -44,12 +44,15 @@ describe('Query', () => {
     });
     ok(phrase);
   });
-  
+
   it('should handle boosts on terms that are predefined in constant', () => {
     const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
     const existingTermQuery = new Query('aggregation').getCompound(null, []);
     ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
-    ok(((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value as unknown as number) === 100);
+    ok(
+      ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost
+        ?.value as unknown as number) === 100
+    );
   });
 });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -1,5 +1,6 @@
-import { deepStrictEqual } from 'assert';
+import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
+import { Phrase, CompoundPart } from '../../src/Query/types';
 
 describe('Query', () => {
   it('should parse a single term', () => {
@@ -30,5 +31,17 @@ describe('Query', () => {
     const query = new Query('"officially supported');
     deepStrictEqual(query.terms, new Set(['officially', 'supported']));
     deepStrictEqual(query.phrases, ['officially supported']);
+  });
+
+  it('should look for the phrase as a compound should with a boost', () => {
+    const query = new Query('max disk iops');
+    const compound = query.getCompound(null, []);
+    const phrase = compound.should.find((compoundPart) => {
+      return (
+        typeof compoundPart['phrase' as keyof CompoundPart] === 'object' &&
+        typeof compoundPart['phrase' as keyof CompoundPart]['score'] === 'object'
+      );
+    });
+    ok(phrase);
   });
 });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
-import { Phrase, CompoundPart } from '../../src/Query/types';
+import { CompoundPart } from '../../src/Query/types';
 
 describe('Query', () => {
   it('should parse a single term', () => {

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -33,7 +33,7 @@ describe('Query', () => {
     deepStrictEqual(query.phrases, ['officially supported']);
   });
 
-  it('should look for the phrase as a compound should with a boost', () => {
+  it('should query a multi word phrase as its whole and boost its score', () => {
     const query = new Query('max disk iops');
     const compound = query.getCompound(null, []);
     const phrase = compound.should.find((compoundPart) => {


### PR DESCRIPTION
### Ticket

DOP-3976

### Notes
- Adds a [phrase](https://mongodb.com/docs/atlas/atlas-search/phrase/) operator to search across documents' `paragraphs` `headings` and `text` for the original search phrase with standard analyzer. Added a boost to this score as we would want documents with these words in order to be higher in the ranking

### Staged changes:
Can see the change here:
https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/search/?q=max+disk+iops&page=1

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
