### PR TITLE
DOP-4489: supply list of manifest files in S3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
+      - 'refs/heads/DOP-4489'
 
 steps:
   - name: publish-staging

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ trigger:
     include:
       - 'refs/tags/v*'
       - 'refs/heads/main'
-      - 'refs/heads/DOP-4489'
 
 steps:
   - name: publish-staging

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -8,6 +8,8 @@ env:
   ATLAS_DATABASE: 'search'
   ATLAS_ADMIN_PUB_KEY: 'cbkapemu'
   POOL_DB: 'pool'
+  S3_BUCKET: docs-search-indexes-test
+  S3_PATH: search-indexes/prd
 
 resources:
   limits:

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -8,6 +8,8 @@ env:
   ATLAS_DATABASE: 'search-staging'
   ATLAS_ADMIN_PUB_KEY: 'dgrhrxpv'
   POOL_DB: 'pool_test'
+  S3_BUCKET: docs-search-indexes-test
+  S3_PATH: search-indexes/preprd
 
 resources:
   limits:

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,7 @@
 # URI in s3 for source manifests
 MANIFEST_URI='s3://docs-search-indexes-test/search-indexes/preprd'
+S3_BUCKET= docs-search-indexes-test
+S3_PATH: search-indexes/preprd
 # Database containing indexed search results
 ATLAS_DATABASE='search-staging'
 # Atlas connection string uri

--- a/sample.env
+++ b/sample.env
@@ -1,7 +1,7 @@
 # URI in s3 for source manifests
 MANIFEST_URI='s3://docs-search-indexes-test/search-indexes/preprd'
-S3_BUCKET= docs-search-indexes-test
-S3_PATH: search-indexes/preprd
+S3_BUCKET=docs-search-indexes-test
+S3_PATH=search-indexes/preprd
 # Database containing indexed search results
 ATLAS_DATABASE='search-staging'
 # Atlas connection string uri

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -91,6 +91,10 @@ export default class Marian {
       if (checkMethod(req, res, 'GET')) {
         this.handleStatusV2(req, res);
       }
+    } else if (pathname === '/manifests') {
+      if (checkMethod(req, res, 'GET')) {
+        this.handleManifests(req, res);
+      }
     } else {
       res.writeHead(400, {});
       res.end('');
@@ -310,5 +314,31 @@ export default class Marian {
       console.trace();
       throw e;
     }
+  }
+
+  private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
+    const headers = {
+      'Content-Type': 'application/json',
+      Vary: 'Accept-Encoding, Origin',
+      Pragma: 'no-cache',
+    };
+    Object.assign(headers, STANDARD_HEADERS);
+
+    checkAllowedOrigin(req.headers.origin, headers);
+
+    if (this.index.manifests === null) {
+      res.writeHead(503, headers);
+      res.end('');
+      return;
+    }
+
+    const response = {
+      manifests: this.index.manifests.map((manifest) =>
+        new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString()
+      ),
+    };
+
+    res.writeHead(200, headers);
+    res.end(JSON.stringify(response));
   }
 }

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -32,6 +32,7 @@ const log = new Logger({
 export class SearchIndex {
   currentlyIndexing: boolean;
   manifestSource: string;
+  manifestUrlPrefix: string;
   manifests: Manifest[] | null;
 
   client: MongoClient;
@@ -42,10 +43,11 @@ export class SearchIndex {
   trieFacets: TrieFacet;
   responseFacets: FacetOption[];
 
-  constructor(manifestSource: string, client: MongoClient, databaseName: string) {
+  constructor(manifestSource: string, s3Bucket: string, s3Path: string, client: MongoClient, databaseName: string) {
     this.currentlyIndexing = false;
     this.manifestSource = manifestSource;
     this.manifests = null;
+    this.manifestUrlPrefix = `https://` + `${s3Bucket}.s3.us-east-2.amazonaws.com/${s3Path}`.replace(/\/+/, '/');
 
     this.client = client;
     this.db = client.db(databaseName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ function verifyAndGetEnvVars() {
       console.error(`Missing ${S3_BUCKET_KEY}`);
     }
     if (!s3Path) {
-      console.error(`Missing ${S3_BUCKET_KEY}`);
+      console.error(`Missing ${S3_PATH_KEY}`);
     }
     if (!atlasUri) {
       console.error(`Missing ${ATLAS_URI_KEY}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ import { SearchIndex } from './SearchIndex';
 process.title = 'search-transport';
 
 const MANIFEST_URI_KEY = 'MANIFEST_URI';
+
+const S3_BUCKET_KEY = 'S3_BUCKET';
+const S3_PATH_KEY = 'S3_PATH';
 const ATLAS_URI_KEY = 'ATLAS_URI';
 const DATABASE_NAME_KEY = 'ATLAS_DATABASE';
 const DEFAULT_DATABASE_NAME = 'search';
@@ -29,6 +32,8 @@ function help(): void {
 
 The following environment variables are used:
 * ${MANIFEST_URI_KEY}
+* ${S3_BUCKET_KEY}
+* ${S3_PATH_KEY}
 * ${ATLAS_URI_KEY}
 * ${DATABASE_NAME_KEY} (defaults to "search")
 * ${GROUP_KEY}
@@ -40,15 +45,23 @@ The following environment variables are used:
 
 function verifyAndGetEnvVars() {
   const manifestUri = process.env[MANIFEST_URI_KEY];
+  const s3Bucket = process.env[S3_BUCKET_KEY];
+  const s3Path = process.env[S3_PATH_KEY];
   const atlasUri = process.env[ATLAS_URI_KEY];
   const groupId = process.env[GROUP_KEY];
   const adminPubKey = process.env[ADMIN_PUB_KEY];
   const adminPrivKey = process.env[ADMIN_API_KEY];
   const taxonomyUrl = process.env[TAXONOMY_URL];
 
-  if (!manifestUri || !atlasUri || !groupId || !adminPrivKey || !adminPubKey) {
+  if (!manifestUri || !s3Bucket || !atlasUri || !groupId || !adminPrivKey || !adminPubKey || !s3Path) {
     if (!manifestUri) {
       console.error(`Missing ${MANIFEST_URI_KEY}`);
+    }
+    if (!s3Bucket) {
+      console.error(`Missing ${S3_BUCKET_KEY}`);
+    }
+    if (!s3Path) {
+      console.error(`Missing ${S3_BUCKET_KEY}`);
     }
     if (!atlasUri) {
       console.error(`Missing ${ATLAS_URI_KEY}`);
@@ -71,6 +84,8 @@ function verifyAndGetEnvVars() {
 
   return {
     manifestUri,
+    s3Bucket,
+    s3Path,
     atlasUri,
     groupId,
     adminPubKey,
@@ -91,7 +106,7 @@ async function main() {
     process.exit(1);
   }
 
-  const { manifestUri, atlasUri, groupId, adminPubKey, adminPrivKey } = verifyAndGetEnvVars();
+  const { manifestUri, s3Bucket, s3Path, atlasUri, groupId, adminPubKey, adminPrivKey } = verifyAndGetEnvVars();
 
   let databaseName = DEFAULT_DATABASE_NAME;
   const envDBName = process.env[DATABASE_NAME_KEY];
@@ -100,7 +115,7 @@ async function main() {
   }
 
   const client = await MongoClient.connect(atlasUri);
-  const searchIndex = new SearchIndex(manifestUri, client, databaseName);
+  const searchIndex = new SearchIndex(manifestUri, s3Bucket, s3Path, client, databaseName);
 
   if (process.argv.includes('--create-indexes')) {
     await searchIndex.createRecommendedIndexes();

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -19,7 +19,13 @@ describe('Searching', function () {
 
   before('Loading test data', async function () {
     await client.connect();
-    index = new SearchIndex('dir:tests/integration/search_test_data/', 'docs-search-indexes-test', 'search-indexes/preprd', client, TEST_DATABASE);
+    index = new SearchIndex(
+      'dir:tests/integration/search_test_data/',
+      'docs-search-indexes-test',
+      'search-indexes/preprd',
+      client,
+      TEST_DATABASE
+    );
     const result = await index.load({} as Taxonomy, 'dir:tests/integration/search_test_data/');
     await index.createRecommendedIndexes();
 

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -19,7 +19,7 @@ describe('Searching', function () {
 
   before('Loading test data', async function () {
     await client.connect();
-    index = new SearchIndex('dir:tests/integration/search_test_data/', client, TEST_DATABASE);
+    index = new SearchIndex('dir:tests/integration/search_test_data/', 'docs-search-indexes-test', 'search-indexes/preprd', client, TEST_DATABASE);
     const result = await index.load({} as Taxonomy, 'dir:tests/integration/search_test_data/');
     await index.createRecommendedIndexes();
 

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -24,6 +24,8 @@ export function startServer(path: string, done: () => void): { child: child_proc
       ATLAS_ADMIN_PUB_KEY: process.env.ATLAS_ADMIN_PUB_KEY,
       POOL_ATLAS_URI: process.env.ATLAS_URI,
       TAXONOMY_URL: process.env.TAXONOMY_URL,
+      S3_BUCKET: 'docs-search-indexes-test',
+      S3_PATH: 'search-indexes/preprd',
     },
   });
   child.stdout?.setEncoding('utf8');

--- a/tests/integration/sync.test.ts
+++ b/tests/integration/sync.test.ts
@@ -23,7 +23,7 @@ describe('Synchronization', function () {
 
   before(function (done) {
     client.connect().then(async () => {
-      index = new SearchIndex(PATH_STATE_1, client, DB);
+      index = new SearchIndex(PATH_STATE_1, 'docs-search-indexes-test', 'search-indexes/preprd', client, DB);
       done();
     });
   });


### PR DESCRIPTION
### Ticket

DOP-4489

This change opens up a new route `/manifests` that provides a link of JSON files that smartling's crawlers can access, for pre processing and translations.

### Notes
- Previously, we were setting the full URI for the manifest s3 location, so added a few more env variables without changing the existing logic.
- This does not require any changes to the README but additional changes have been made to env variables (sample env, drone env variables)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
