### PR TITLE
DOP-4503: check that property mapping is only checking for string properties

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -115,6 +115,8 @@ export default class Marian {
     try {
       results = await this.fetchResults(parsedUrl);
     } catch (err) {
+      log.error(`Error while handling search:`);
+      log.error(err);
       if (err instanceof InvalidQuery) {
         res.writeHead(400, headers);
         res.end(err.message);

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -109,7 +109,9 @@ export class Query {
     const searchPropertyMapping = getPropertyMapping();
 
     // if we need to boost for matching slug on an exact rawQuery match
-    if (strippedMapping[this.rawQuery.trim()]) {
+    const boostedStrings = strippedMapping[this.rawQuery.trim()];
+    if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
+      // if ( strippedMapping[this.rawQuery.trim()]) {
       parts.push({
         text: {
           path: 'strippedSlug',

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -111,7 +111,6 @@ export class Query {
     // if we need to boost for matching slug on an exact rawQuery match
     const boostedStrings = strippedMapping[this.rawQuery.trim()];
     if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
-      // if ( strippedMapping[this.rawQuery.trim()]) {
       parts.push({
         text: {
           path: 'strippedSlug',

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -114,7 +114,7 @@ export class Query {
       parts.push({
         text: {
           path: 'strippedSlug',
-          query: strippedMapping[this.rawQuery.trim()],
+          query: boostedStrings,
           score: { boost: { value: 100 } },
         },
       });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from 'assert';
+import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
 
 describe('Query', () => {
@@ -30,5 +30,13 @@ describe('Query', () => {
     const query = new Query('"officially supported');
     deepStrictEqual(query.terms, new Set(['officially', 'supported']));
     deepStrictEqual(query.phrases, ['officially supported']);
+  });
+
+  it('should handle boosts on terms that are predefined in constant', () => {
+    const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
+    ok((nonExistingTermQuery.should[0].compound.must[0].text?.score?.boost?.value as unknown as number) !== 100);
+    const existingTermQuery = new Query('aggregation').getCompound(null, []);
+    ok(existingTermQuery.should[0].compound.must[0].text?.score?.boost !== undefined);
+    ok((existingTermQuery.should[0].compound.must[0].text?.score?.boost?.value as unknown as number) === 100);
   });
 });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -34,7 +34,7 @@ describe('Query', () => {
 
   it('should handle boosts on terms that are predefined in constant', () => {
     const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
-    ok((nonExistingTermQuery.should[0].compound.must[0].text?.score?.boost?.value as unknown as number) !== 100);
+    ok(nonExistingTermQuery.should[0].compound.must[0].text?.score?.boost?.value === undefined);
     const existingTermQuery = new Query('aggregation').getCompound(null, []);
     ok(existingTermQuery.should[0].compound.must[0].text?.score?.boost !== undefined);
     ok((existingTermQuery.should[0].compound.must[0].text?.score?.boost?.value as unknown as number) === 100);


### PR DESCRIPTION
### Ticket

DOP-4503

### Notes
- See ticket for explanation of bug. [In the case shown in this log](https://mongodb.splunkcloud.com/en-US/app/search/show_source?sid=scheduler_cmF5bXVuZC5yb2RyaWd1ZXo__search__RMD5f5aaa11866325be7_at_1712116800_3520&offset=0&latest_time=), user is searching for `constructor` which exists as a property on the object, but does not exist in the constant mapping as a key. The fix here is to check that the property exists as a type of `String[]`
- Added this case as a unit test to prevent future errors of the same kind.


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
