### PR TITLE
DOP-4323: Boost query matches on taxonomy values

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -101,6 +101,7 @@ steps:
         - push
       ref:
         - 'refs/heads/main'
+        - 'refs/heads/DOP-4323'
 
   - name: deploy-prod
     image: quay.io/mongodb/drone-helm:v3

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -181,6 +181,14 @@ export class Query {
       },
     });
 
+    parts.push({
+      text: {
+        query: terms,
+        path: 'facets',
+        score: { boost: { value: 10 } },
+      },
+    });
+
     const compound: Compound = {
       should: constructBuryOperators(parts),
       minimumShouldMatch: 1,

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -184,7 +184,13 @@ export class Query {
     parts.push({
       text: {
         query: terms,
-        path: 'facets',
+        path: [
+          'facets.genre',
+          'facets.programming_language',
+          'facets.target_product',
+          'facets.target_product>atlas>sub_product',
+          'facets.target_product>realm>sub_product',
+        ],
         score: { boost: { value: 10 } },
       },
     });

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -30,7 +30,7 @@ export type CompoundPart = {
   };
 };
 
-type Phrase = {
+export type Phrase = {
   phrase: {
     path: string | string[];
     query: string | string[];

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -77,7 +77,6 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
 
     // if subproduct, remove parent
     if (drilldownKeyIdx > -1) {
-      // retrieve parent product from key
       const parent = key.slice(drilldownKeyIdx + 1, key.indexOf('>', drilldownKeyIdx + 1));
       const indexOfParent = queryParamLists[baseFacet].compound.should.findIndex(
         (element: Phrase) => element.phrase.query === parent

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -75,15 +75,6 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
       },
     };
 
-    // if subproduct, remove parent
-    if (drilldownKeyIdx > -1) {
-      const parent = key.slice(drilldownKeyIdx + 1, key.indexOf('>', drilldownKeyIdx + 1));
-      const indexOfParent = queryParamLists[baseFacet].compound.should.findIndex(
-        (element: Phrase) => element.phrase.query === parent
-      );
-      if (indexOfParent > -1) queryParamLists[baseFacet].compound.should.splice(indexOfParent, 1);
-    }
-
     queryParamLists[baseFacet]['compound']['should'].push({
       phrase: {
         query: value,

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -61,9 +61,6 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   for (const [key, value] of searchParams) {
     // key = 'facets.target_product>atlas>sub_product'
     // value = 'search'
-    console.log('\n\n\n---------------------------------');
-    console.log('key', key);
-    console.log('value', value);
     if (!key.startsWith(FACET_PREFIX)) {
       continue;
     }
@@ -72,32 +69,21 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
     const drilldownKeyIdx = key.indexOf('>');
     const baseFacet = drilldownKeyIdx > -1 ? key.slice(0, drilldownKeyIdx) : key;
 
-    console.log('BASE FACET', baseFacet);
-    // if it's a facet that's a subproduct
-    // we want to get rid of parent product if it exists
-
-    console.log('KEY', key);
-
-    console.log('QUERY PARAM LISTS', JSON.stringify(queryParamLists, null, 2));
-    console.log('QUEWRY PARAM LISTS AT BASEFACET', JSON.stringify(queryParamLists[baseFacet], null, 2));
     queryParamLists[baseFacet] = queryParamLists[baseFacet] || {
       compound: {
         should: [],
       },
     };
-    console.log('QUERY PARAM LISTS3', JSON.stringify(queryParamLists, null, 2));
+
     // if subproduct, remove parent
     if (drilldownKeyIdx > -1) {
       // retrieve parent product from key
       const parent = key.slice(drilldownKeyIdx + 1, key.indexOf('>', drilldownKeyIdx + 1));
-      console.log('PARENT VALUE', parent);
       const indexOfParent = queryParamLists[baseFacet].compound.should.findIndex(
         (element: Phrase) => element.phrase.query === parent
       );
-      console.log('INDEX OF PARENT', indexOfParent);
       if (indexOfParent > -1) queryParamLists[baseFacet].compound.should.splice(indexOfParent, 1);
     }
-    console.log('QUERY PARAM LISTS4', JSON.stringify(queryParamLists, null, 2));
 
     queryParamLists[baseFacet]['compound']['should'].push({
       phrase: {
@@ -105,9 +91,7 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
         path: key,
       },
     });
-    console.log('QUERY PARAM LISTS5', JSON.stringify(queryParamLists, null, 2));
   }
-
   return Object.values(queryParamLists);
 };
 

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -58,8 +58,11 @@ describe('Query', () => {
   });
 
   it('should have as many clauses as filters passed into the query', () => {
-    const searchParams = new URLSearchParams(`q=test&facets.target_product=atlas&facets.target_product=drivers`);
+    const searchParams = new URLSearchParams(
+      `q=test&facets.target_product=atlas&facets.target_product=drivers&facets.programming_language=go`
+    );
     const filters = extractFacetFilters(searchParams);
-    ok(filters[0].compound.should.length === 2);
+    const clauses = filters.reduceRight((sum, filter) => sum + filter.compound.should.length, 0);
+    ok(clauses === 3);
   });
 });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
 import { CompoundPart, NestedCompound } from '../../src/Query/types';
+import { extractFacetFilters } from '../../src/Query/util';
 
 describe('Query', () => {
   it('should parse a single term', () => {
@@ -54,5 +55,11 @@ describe('Query', () => {
       ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost
         ?.value as unknown as number) === 100
     );
+  });
+
+  it('should have as many clauses as filters passed into the query', () => {
+    const searchParams = new URLSearchParams(`q=test&facets.target_product=atlas&facets.target_product=drivers`);
+    const filters = extractFacetFilters(searchParams);
+    ok(filters[0].compound.should.length === 2);
   });
 });

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -59,10 +59,12 @@ describe('Query', () => {
 
   it('should have as many clauses as filters passed into the query', () => {
     const searchParams = new URLSearchParams(
-      `q=test&facets.target_product=atlas&facets.target_product=drivers&facets.programming_language=go`
+      `q=test&facets.target_product=drivers&facets.target_product>atlas>sub_product=atlas-cli&facets.programming_language=go`
     );
     const filters = extractFacetFilters(searchParams);
-    const clauses = filters.reduceRight((sum, filter) => sum + filter.compound.should.length, 0);
-    ok(clauses === 3);
+    const and = filters.length;
+    // count number of OR clauses in each compound
+    const or = filters.map((filter) => filter.compound.should.length);
+    ok(and === 2 && or[0] === 2 && or[1] === 1);
   });
 });


### PR DESCRIPTION
### Ticket

DOP-4323

### Notes

Add text matching on facet values. Also fixed a bug in which selected facets were being overwritten by the last facet in the list, as well as added a test to check that the amount of clauses created by `extractFacetFilters()` is the same as the amount of facets passed in through the URL.

Staging link at https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/search/

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
