### PR TITLE
DOP-3934: update custom analyzer to escape $

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,7 @@ steps:
         - push
       ref:
         - 'refs/heads/main'
+        - 'refs/heads/DOP-3934'
 
   - name: publish-prod
     image: plugins/ecr
@@ -101,6 +102,7 @@ steps:
         - push
       ref:
         - 'refs/heads/main'
+        - 'refs/heads/DOP-3934'
 
   - name: deploy-prod
     image: quay.io/mongodb/drone-helm:v3

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -108,18 +108,17 @@ export class Query {
     const parts: Part[] = [];
     const searchPropertyMapping = getPropertyMapping();
 
-    // DOP-3934 - test without having this hardcoded matches
     // if we need to boost for matching slug on an exact rawQuery match
-    // const boostedStrings = strippedMapping[this.rawQuery.trim()];
-    // if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
-    //   parts.push({
-    //     text: {
-    //       path: 'strippedSlug',
-    //       query: boostedStrings,
-    //       score: { boost: { value: 100 } },
-    //     },
-    //   });
-    // }
+    const boostedStrings = strippedMapping[this.rawQuery.trim()];
+    if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
+      parts.push({
+        text: {
+          path: 'strippedSlug',
+          query: boostedStrings,
+          score: { boost: { value: 100 } },
+        },
+      });
+    }
 
     parts.push({
       text: {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -108,22 +108,30 @@ export class Query {
     const parts: Part[] = [];
     const searchPropertyMapping = getPropertyMapping();
 
+    // DOP-3934 - test without having this hardcoded matches
     // if we need to boost for matching slug on an exact rawQuery match
-    const boostedStrings = strippedMapping[this.rawQuery.trim()];
-    if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
-      parts.push({
-        text: {
-          path: 'strippedSlug',
-          query: boostedStrings,
-          score: { boost: { value: 100 } },
-        },
-      });
-    }
+    // const boostedStrings = strippedMapping[this.rawQuery.trim()];
+    // if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
+    //   parts.push({
+    //     text: {
+    //       path: 'strippedSlug',
+    //       query: boostedStrings,
+    //       score: { boost: { value: 100 } },
+    //     },
+    //   });
+    // }
 
     parts.push({
       text: {
         query: terms,
-        path: ['code.lang', 'paragraphs', 'code.value', 'text', { value: 'code.value', multi: 'simple' }],
+        path: [
+          'code.lang',
+          'paragraphs',
+          'code.value',
+          'text',
+          { value: 'code.value', multi: 'simple' },
+          { value: 'paragraphs', multi: 'whitespace' },
+        ],
       },
     });
 

--- a/src/data/atlas-search-index.ts
+++ b/src/data/atlas-search-index.ts
@@ -53,7 +53,7 @@ export const SearchIndex: IndexMappings = {
         analyzer: 'lucene.english',
         multi: {
           whitespace: {
-            analyzer: 'custom.whitespace',
+            analyzer: 'custom.dollar',
             store: false,
             type: 'string',
           },
@@ -71,6 +71,11 @@ export const SearchIndex: IndexMappings = {
         searchAnalyzer: 'lucene.english',
         type: 'string',
         multi: {
+          whitespace: {
+            analyzer: 'custom.dollar',
+            store: false,
+            type: 'string',
+          },
           synonymAnalyzer: {
             analyzer: 'synonym.whitespace',
             type: 'string',
@@ -103,7 +108,7 @@ export const SearchIndex: IndexMappings = {
         analyzer: 'lucene.english',
         multi: {
           whitespace: {
-            analyzer: 'custom.whitespace',
+            analyzer: 'custom.dollar',
             store: false,
             type: 'string',
           },
@@ -142,18 +147,13 @@ export const SearchIndex: IndexMappings = {
       tokenFilters: [{ type: 'lowercase' }],
     },
     {
-      charFilters: [],
-      name: 'custom.whitespace',
-      tokenFilters: [
+      name: 'custom.dollar',
+      charFilters: [
         {
-          matches: 'all',
-          pattern: '^(?!\\$)\\w+',
-          replacement: '',
-          type: 'regex',
-        },
-        {
-          type: 'stopword',
-          tokens: [''],
+          type: 'mapping',
+          mappings: {
+            '\\$': '__dollar_',
+          },
         },
       ],
       tokenizer: {

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -46,17 +46,6 @@ describe('Query', () => {
     ok(phrase);
   });
 
-  it('should handle boosts on terms that are predefined in constant', () => {
-    const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
-    ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
-    const existingTermQuery = new Query('aggregation').getCompound(null, []);
-    ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
-    ok(
-      ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost
-        ?.value as unknown as number) === 100
-    );
-  });
-
   it('should have as many clauses as filters passed into the query', () => {
     const searchParams = new URLSearchParams(
       `q=test&facets.target_product=drivers&facets.target_product>atlas>sub_product=atlas-cli&facets.programming_language=go`

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -46,6 +46,17 @@ describe('Query', () => {
     ok(phrase);
   });
 
+  it('should handle boosts on terms that are predefined in constant', () => {
+    const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
+    ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
+    const existingTermQuery = new Query('aggregation').getCompound(null, []);
+    ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
+    ok(
+      ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost
+        ?.value as unknown as number) === 100
+    );
+  });
+
   it('should have as many clauses as filters passed into the query', () => {
     const searchParams = new URLSearchParams(
       `q=test&facets.target_product=drivers&facets.target_product>atlas>sub_product=atlas-cli&facets.programming_language=go`


### PR DESCRIPTION
### Ticket

DOP-3934

### Notes
- Updates custom analyzer to a simple mapping vs regex token filter
- Also removes the [hard coded mapping](https://github.com/mongodb/docs-search-transport/blob/main/src/data/term-result-mappings.ts) from the query as this shouldn't be needed anymore



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
