### PR TITLE
DOP-4552: Get facet names programmatically in Query/index.ts

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -196,7 +196,6 @@ export default class Marian {
   async load(initLoad = true) {
     let taxonomy: Taxonomy;
     try {
-      // TODO: include taxonomy url in verifyEnvVars after it has been released
       taxonomy = await this.fetchTaxonomy(process.env.TAXONOMY_URL!);
       await setPropertyMapping();
       if (!initLoad) {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -288,8 +288,6 @@ export class Query {
   getMetaQuery(searchProperty: string[] | null, taxonomy: FacetOption[], filters: Filter<Document>[]): mdbDocument[] {
     const compound: Compound = this.getCompound(searchProperty, filters, taxonomy);
 
-    //console.log('TAXONOMY', taxonomy);
-
     const facets = getFacetAggregationStages(taxonomy);
 
     const agg = [

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -188,10 +188,12 @@ export class Query {
       },
     });
 
+    const facetNames = facetKeys.map((facet) => `facets.${facet}`);
+
     parts.push({
       text: {
         query: terms,
-        path: facetKeys,
+        path: facetNames,
         score: { boost: { value: 10 } },
       },
     });

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -61,14 +61,7 @@ export class SearchIndex {
     this.responseFacets = [];
   }
 
-  async search(
-    query: Query,
-    searchProperty: string[] | null,
-    filters: Filter<Document>[],
-    pageNumber?: number /*taxonomy*/
-  ) {
-    //console.log('UMMMMM TRIEFACET', JSON.stringify(this.trieFacets, null, 2));
-    //console.log('RESPONSEFACETSBABEY', JSON.stringify(this.responseFacets, null, 2));
+  async search(query: Query, searchProperty: string[] | null, filters: Filter<Document>[], pageNumber?: number) {
     const aggregationQuery = query.getAggregationQuery(searchProperty, filters, this.responseFacets, pageNumber);
     const cursor = this.documents.aggregate(aggregationQuery);
     return cursor.toArray();

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -3,6 +3,10 @@ import { Query } from '../../src/Query';
 import { SearchIndex } from '../../src/SearchIndex';
 import { Taxonomy } from '../../src/SearchIndex/types';
 import { MongoClient } from 'mongodb';
+import { sampleFacetOption } from '../resources/utils-data';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 const TEST_DATABASE = 'search-test';
 
@@ -28,6 +32,9 @@ describe('Searching', function () {
         TEST_DATABASE
       );
       const result = await index.load({} as Taxonomy, 'dir:tests/integration/search_test_data/');
+      // manually set index response facets to ensure test doesn't
+      // fail due to empty facet text match
+      index.responseFacets = sampleFacetOption;
       console.log('index loaded');
       await index.createRecommendedIndexes();
       console.log('created recommended indexes');

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -3,7 +3,7 @@ import { Query } from '../../src/Query';
 import { SearchIndex } from '../../src/SearchIndex';
 import { Taxonomy } from '../../src/SearchIndex/types';
 import { MongoClient } from 'mongodb';
-import { sampleFacetOption } from '../resources/utils-data';
+import { sampleFacetKeys } from '../resources/utils-data';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -32,9 +32,9 @@ describe('Searching', function () {
         TEST_DATABASE
       );
       const result = await index.load({} as Taxonomy, 'dir:tests/integration/search_test_data/');
-      // manually set index response facets to ensure test doesn't
+      // manually set facets to ensure test doesn't
       // fail due to empty facet text match
-      index.responseFacets = sampleFacetOption;
+      index.facetKeys = sampleFacetKeys;
       console.log('index loaded');
       await index.createRecommendedIndexes();
       console.log('created recommended indexes');

--- a/tests/resources/utils-data.ts
+++ b/tests/resources/utils-data.ts
@@ -297,3 +297,11 @@ export const sampleFacetOption = [
     ],
   },
 ] as FacetOption[];
+
+export const sampleFacetKeys = [
+  'genre',
+  'target_product>atlas>sub_product',
+  'target_product>realm>sub_product',
+  'target_product',
+  'programming_language',
+];

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
 import { CompoundPart, NestedCompound } from '../../src/Query/types';
 import { extractFacetFilters } from '../../src/Query/util';
+import { sampleFacetOption } from '../resources/utils-data';
 
 describe('Query', () => {
   it('should parse a single term', () => {
@@ -36,7 +37,7 @@ describe('Query', () => {
 
   it('should query a multi word phrase as its whole and boost its score', () => {
     const query = new Query('max disk iops');
-    const compound = query.getCompound(null, [], []);
+    const compound = query.getCompound(null, [], sampleFacetOption);
     const phrase = compound.should.find((compoundPart) => {
       return (
         typeof compoundPart['phrase' as keyof CompoundPart] === 'object' &&
@@ -47,9 +48,9 @@ describe('Query', () => {
   });
 
   it('should handle boosts on terms that are predefined in constant', () => {
-    const nonExistingTermQuery = new Query('constructor').getCompound(null, [], []);
+    const nonExistingTermQuery = new Query('constructor').getCompound(null, [], sampleFacetOption);
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
-    const existingTermQuery = new Query('aggregation').getCompound(null, [], []);
+    const existingTermQuery = new Query('aggregation').getCompound(null, [], sampleFacetOption);
     ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
     ok(
       ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -36,7 +36,7 @@ describe('Query', () => {
 
   it('should query a multi word phrase as its whole and boost its score', () => {
     const query = new Query('max disk iops');
-    const compound = query.getCompound(null, []);
+    const compound = query.getCompound(null, [], []);
     const phrase = compound.should.find((compoundPart) => {
       return (
         typeof compoundPart['phrase' as keyof CompoundPart] === 'object' &&
@@ -47,9 +47,9 @@ describe('Query', () => {
   });
 
   it('should handle boosts on terms that are predefined in constant', () => {
-    const nonExistingTermQuery = new Query('constructor').getCompound(null, []);
+    const nonExistingTermQuery = new Query('constructor').getCompound(null, [], []);
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
-    const existingTermQuery = new Query('aggregation').getCompound(null, []);
+    const existingTermQuery = new Query('aggregation').getCompound(null, [], []);
     ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
     ok(
       ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -2,7 +2,7 @@ import { deepStrictEqual, ok } from 'assert';
 import { Query } from '../../src/Query';
 import { CompoundPart, NestedCompound } from '../../src/Query/types';
 import { extractFacetFilters } from '../../src/Query/util';
-import { sampleFacetOption } from '../resources/utils-data';
+import { sampleFacetKeys } from '../resources/utils-data';
 
 describe('Query', () => {
   it('should parse a single term', () => {
@@ -37,7 +37,7 @@ describe('Query', () => {
 
   it('should query a multi word phrase as its whole and boost its score', () => {
     const query = new Query('max disk iops');
-    const compound = query.getCompound(null, [], sampleFacetOption);
+    const compound = query.getCompound(null, [], sampleFacetKeys);
     const phrase = compound.should.find((compoundPart) => {
       return (
         typeof compoundPart['phrase' as keyof CompoundPart] === 'object' &&
@@ -48,9 +48,9 @@ describe('Query', () => {
   });
 
   it('should handle boosts on terms that are predefined in constant', () => {
-    const nonExistingTermQuery = new Query('constructor').getCompound(null, [], sampleFacetOption);
+    const nonExistingTermQuery = new Query('constructor').getCompound(null, [], sampleFacetKeys);
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
-    const existingTermQuery = new Query('aggregation').getCompound(null, [], sampleFacetOption);
+    const existingTermQuery = new Query('aggregation').getCompound(null, [], sampleFacetKeys);
     ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
     ok(
       ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost


### PR DESCRIPTION
### Ticket

DOP-4552 

### Notes

I wanted to leverage the existing `getFacetKeys` function in Search Index, but obtaining the taxonomy and passing it into this function outside `AtlasAdmin` proved a bit cumbersome.

This solution is the main one that comes to mind, but open to any suggestions for better code structure or locally storing the facet key names into a member of `SearchIndex`, similar to [insertTaxonomyIntoSearchIndex](https://github.com/mongodb/docs-search-transport/blob/main/src/AtlasAdmin/index.ts#L155) but to my knowledge the results of this function are only being uploaded online and doesn't exist locally/in a way that's easily accessible to `Query`.


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
