### PR TITLE
DOP-4593: Search endpoint to return HTML format for manifest list

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -346,6 +346,6 @@ export default class Marian {
     };
 
     res.writeHead(200, headers);
-    res.end(response());
+    res.end('hello');
   }
 }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -347,14 +347,12 @@ export default class Marian {
     }
 
     let manifestList = '';
-    let endList = 'gah';
     const openTags = '<a href=';
-    const hrefClose = '>  ';
-    const closeTags = '  </a>';
-    for (let i = 0; i < this.index.manifests.length; i++) {
-      const manifestUrl = new URL(
-        `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
-      ).toString();
+    const hrefClose = '>';
+    const closeTags = '</a>';
+    const urlPrefix = this.index.manifestUrlPrefix;
+    for (let manifest of this.index.manifests) {
+      const manifestUrl = new URL(`${urlPrefix}/${manifest.searchProperty}.json`).toString();
       manifestList += openTags + manifestUrl + hrefClose + manifestUrl + closeTags;
     }
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -348,6 +348,7 @@ export default class Marian {
 
     const manifestList = '';
     let otherList = 'start';
+    let endList = 'gah';
     const openTags = '<a href=';
     const closeTags = '></a>';
     for (let i = 0; i < this.index.manifests.length; i++) {
@@ -356,9 +357,10 @@ export default class Marian {
       ).toString();
       manifestList.concat(manifestUrl);
       otherList += 'Middle';
+      endList = 'end';
     }
 
-    const response = this.index.manifests.length + otherList + '<html><body>' + '</body></html>';
+    const response = this.index.manifests.length + otherList + endList + '<html><body>' + '</body></html>';
     console.log(manifestList);
     console.log('Hello there');
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -4,7 +4,6 @@ import Logger from 'basic-logger';
 import http from 'http';
 import { parse } from 'toml';
 import { Document } from 'mongodb';
-
 import { checkAllowedOrigin, checkMethod } from './util';
 import { StatusResponse } from './types';
 import { SearchIndex } from '../SearchIndex';
@@ -319,7 +318,7 @@ export default class Marian {
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {
-      'Content-Type': 'application/json',
+      'Content-Type': 'text/html',
       Vary: 'Accept-Encoding, Origin',
       Pragma: 'no-cache',
     };
@@ -333,10 +332,17 @@ export default class Marian {
       return;
     }
 
-    const response = {
-      manifests: this.index.manifests.map((manifest) =>
-        new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString()
-      ),
+    const response = () => {
+      let manifestList = '';
+      const openTags = '<a href=';
+      const closeTags = '></a>'
+      if (this.index.manifests){
+        for (let manifest of this.index.manifests) {
+          const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+          manifestList += openTags + manifestUrl+closeTags;
+        }
+    }
+      return `<html><body> ${manifestList} </body></html>`
     };
 
     res.writeHead(200, headers);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -346,6 +346,6 @@ export default class Marian {
     };
 
     res.writeHead(200, headers);
-    res.end(JSON.stringify(response));
+    res.end(response());
   }
 }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -346,15 +346,17 @@ export default class Marian {
       return;
     }
 
-    let manifestList = '';
+    const manifestList = '';
+    const otherList = 'start';
     const openTags = '<a href=';
     const closeTags = '></a>';
     for (let manifest of this.index.manifests) {
       const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
       manifestList.concat(manifestUrl);
+      otherList.concat('Middle');
     }
 
-    const response = this.index.manifests.length + '<html><body>' + manifestList + '</body></html>';
+    const response = this.index.manifests.length + otherList + '<html><body>' + '</body></html>';
     console.log(manifestList);
     console.log('Hello there');
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -347,7 +347,7 @@ export default class Marian {
     }
 
     const manifestList = '';
-    const otherList = 'start';
+    let otherList = 'start';
     const openTags = '<a href=';
     const closeTags = '></a>';
     for (let i = 0; i < this.index.manifests.length; i++) {
@@ -355,7 +355,7 @@ export default class Marian {
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
       ).toString();
       manifestList.concat(manifestUrl);
-      otherList.concat('Middle');
+      otherList += 'Middle';
     }
 
     const response = this.index.manifests.length + otherList + '<html><body>' + '</body></html>';

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -316,20 +316,20 @@ export default class Marian {
     }
   }
 
-  private formatManifests = () =>{
-    return ("hello again"); 
+  private formatManifests = () => {
+    return 'hello again';
   };
-//         let manifestList = '';
-//     const openTags = '<a href=';
-//     const closeTags = '></a>';
-//     if (this.index.manifests) {
-//       for (let manifest of this.index.manifests) {
-//         const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-//         manifestList += openTags + manifestUrl + closeTags;
-//       }
-//     }
-//     return `<html><body> ${manifestList} </body></html>`;
-// };
+  //         let manifestList = '';
+  //     const openTags = '<a href=';
+  //     const closeTags = '></a>';
+  //     if (this.index.manifests) {
+  //       for (let manifest of this.index.manifests) {
+  //         const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+  //         manifestList += openTags + manifestUrl + closeTags;
+  //       }
+  //     }
+  //     return `<html><body> ${manifestList} </body></html>`;
+  // };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {
@@ -348,7 +348,7 @@ export default class Marian {
     }
 
     const response = this.formatManifests();
-    
+
     res.writeHead(200, headers);
     res.end(response);
   }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -356,11 +356,10 @@ export default class Marian {
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
       ).toString();
       manifestList.concat(manifestUrl);
-      otherList += 'Middle';
       endList = 'end';
     }
 
-    const response = this.index.manifests.length + otherList + endList + '<html><body>' + '</body></html>';
+    const response = this.index.manifests.length + manifestList + endList + '<html><body>' + '</body></html>';
     console.log(manifestList);
     console.log('Hello there');
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -349,7 +349,7 @@ export default class Marian {
     let manifestList = '';
     let endList = 'gah';
     const openTags = '<a href=';
-    const hrefClose = '>';
+    const hrefClose = ' >';
     const closeTags = '</a>';
     for (let i = 0; i < this.index.manifests.length; i++) {
       const manifestUrl = new URL(

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -316,20 +316,6 @@ export default class Marian {
     }
   }
 
-  //change format of tags so that url is also in each anchor tag
-  private formatManifests = (manifests: any) => {
-    //   return 'hello thrice';
-    // };
-    let manifestList = '';
-    const openTags = '<a href=';
-    const closeTags = '></a>';
-    for (let manifest of manifests) {
-      const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-      manifestList += openTags + manifestUrl + closeTags;
-    }
-    return manifests.length + '<html><body>' + manifestList + '</body></html>';
-  };
-
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {
       'Content-Type': 'text/html',

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -351,7 +351,7 @@ export default class Marian {
     const closeTags = '></a>';
     for (let manifest of this.index.manifests) {
       const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-      manifestList += openTags + manifestUrl + closeTags;
+      manifestList.concat(manifestUrl);
     }
 
     const response = this.index.manifests.length + '<html><body>' + manifestList + '</body></html>';

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -329,7 +329,7 @@ export default class Marian {
         manifestList += openTags + manifestUrl + closeTags;
       }
     }
-    return '<html><body> ${manifestList} </body></html>';
+    return '<html><body>' + manifestList + '</body></html>';
   };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -335,14 +335,14 @@ export default class Marian {
     const response = () => {
       let manifestList = '';
       const openTags = '<a href=';
-      const closeTags = '></a>'
-      if (this.index.manifests){
+      const closeTags = '></a>';
+      if (this.index.manifests) {
         for (let manifest of this.index.manifests) {
           const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-          manifestList += openTags + manifestUrl+closeTags;
+          manifestList += openTags + manifestUrl + closeTags;
         }
-    }
-      return `<html><body> ${manifestList} </body></html>`
+      }
+      return `<html><body> ${manifestList} </body></html>`;
     };
 
     res.writeHead(200, headers);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -354,10 +354,11 @@ export default class Marian {
       manifestList += openTags + manifestUrl + closeTags;
     }
 
+    const response = this.index.manifests.length + '<html><body>' + manifestList + '</body></html>';
     console.log(manifestList);
     console.log('Hello again');
 
     res.writeHead(200, headers);
-    res.end(manifestList);
+    res.end(response);
   }
 }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -349,8 +349,8 @@ export default class Marian {
     let manifestList = '';
     let endList = 'gah';
     const openTags = '<a href=';
-    const hrefClose = ' >';
-    const closeTags = '</a>';
+    const hrefClose = '>  ';
+    const closeTags = '  </a>';
     for (let i = 0; i < this.index.manifests.length; i++) {
       const manifestUrl = new URL(
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
@@ -358,9 +358,7 @@ export default class Marian {
       manifestList += openTags + manifestUrl + hrefClose + manifestUrl + closeTags;
     }
 
-    const response = endList + '<html><body>' + manifestList + '</body></html>';
-    console.log(manifestList);
-    console.log('Hello there');
+    const response = '<html><body>' + manifestList + '</body></html>';
 
     res.writeHead(200, headers);
     res.end(response);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -346,9 +346,18 @@ export default class Marian {
       return;
     }
 
-    const response = this.formatManifests(this.index.manifests);
+    let manifestList = '';
+    const openTags = '<a href=';
+    const closeTags = '></a>';
+    for (let manifest of this.index.manifests) {
+      const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+      manifestList += openTags + manifestUrl + closeTags;
+    }
+
+    console.log(manifestList);
+    console.log('Hello');
 
     res.writeHead(200, headers);
-    res.end(response);
+    res.end(manifestList);
   }
 }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -317,19 +317,17 @@ export default class Marian {
   }
 
   //change format of tags so that url is also in each anchor tag
-  private formatManifests = () => {
+  private formatManifests = (manifests) => {
     //   return 'hello thrice';
     // };
     let manifestList = '';
     const openTags = '<a href=';
     const closeTags = '></a>';
-    if (this.index.manifests) {
-      for (let manifest of this.index.manifests) {
-        const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-        manifestList += openTags + manifestUrl + closeTags;
-      }
+    for (let manifest of manifests) {
+      const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+      manifestList += openTags + manifestUrl + closeTags;
     }
-    return '<html><body>' + manifestList + '</body></html>';
+    return manifests.length + '<html><body>' + manifestList + '</body></html>';
   };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
@@ -348,7 +346,7 @@ export default class Marian {
       return;
     }
 
-    const response = this.formatManifests();
+    const response = this.formatManifests(this.index.manifests);
 
     res.writeHead(200, headers);
     res.end(response);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -317,19 +317,19 @@ export default class Marian {
   }
 
   private formatManifests = () => {
-    //   return 'hello again';
-    // };
-    let manifestList = '';
-    const openTags = '<a href=';
-    const closeTags = '></a>';
-    if (this.index.manifests) {
-      for (let manifest of this.index.manifests) {
-        const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-        manifestList += openTags + manifestUrl + closeTags;
-      }
-    }
-    return `<html><body> ${manifestList} </body></html>`;
+    return 'hello thrice';
   };
+  //   let manifestList = '';
+  //   const openTags = '<a href=';
+  //   const closeTags = '></a>';
+  //   if (this.index.manifests) {
+  //     for (let manifest of this.index.manifests) {
+  //       const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+  //       manifestList += openTags + manifestUrl + closeTags;
+  //     }
+  //   }
+  //   return `<html><body> ${manifestList} </body></html>`;
+  // };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -316,18 +316,19 @@ export default class Marian {
     }
   }
 
+  //change format of tags so that url is also in each anchor tag
   private formatManifests = () => {
     //   return 'hello thrice';
     // };
     let manifestList = '';
     const openTags = '<a href=';
     const closeTags = '></a>';
-    // if (this.index.manifests) {
-    //   for (let manifest of this.index.manifests) {
-    //     const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-    //     manifestList += openTags + manifestUrl + closeTags;
-    //   }
-    // }
+    if (this.index.manifests) {
+      for (let manifest of this.index.manifests) {
+        const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+        manifestList += openTags + manifestUrl + closeTags;
+      }
+    }
     return '<html><body> ${manifestList} </body></html>';
   };
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -354,7 +354,7 @@ export default class Marian {
       const manifestUrl = new URL(
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
       ).toString();
-      manifestList += manifestUrl;
+      manifestList += 'hi' + manifestUrl;
       endList = 'end';
     }
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -316,6 +316,21 @@ export default class Marian {
     }
   }
 
+  private formatManifests = () =>{
+    return ("hello again"); 
+  };
+//         let manifestList = '';
+//     const openTags = '<a href=';
+//     const closeTags = '></a>';
+//     if (this.index.manifests) {
+//       for (let manifest of this.index.manifests) {
+//         const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+//         manifestList += openTags + manifestUrl + closeTags;
+//       }
+//     }
+//     return `<html><body> ${manifestList} </body></html>`;
+// };
+
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {
       'Content-Type': 'text/html',
@@ -332,20 +347,9 @@ export default class Marian {
       return;
     }
 
-    const response = () => {
-      let manifestList = '';
-      const openTags = '<a href=';
-      const closeTags = '></a>';
-      if (this.index.manifests) {
-        for (let manifest of this.index.manifests) {
-          const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-          manifestList += openTags + manifestUrl + closeTags;
-        }
-      }
-      return `<html><body> ${manifestList} </body></html>`;
-    };
-
+    const response = this.formatManifests();
+    
     res.writeHead(200, headers);
-    res.end('hello');
+    res.end(response);
   }
 }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -355,7 +355,7 @@ export default class Marian {
     }
 
     console.log(manifestList);
-    console.log('Hello');
+    console.log('Hello again');
 
     res.writeHead(200, headers);
     res.end(manifestList);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -333,16 +333,16 @@ export default class Marian {
     }
 
     let manifestList = '';
-    const openTags = '<a href=';
+    const openTags = '<div><a href=';
     const hrefClose = '>';
-    const closeTags = '</a>';
+    const closeTags = '</a><div> \n';
     const urlPrefix = this.index.manifestUrlPrefix;
     for (let manifest of this.index.manifests) {
       const manifestUrl = new URL(`${urlPrefix}/${manifest.searchProperty}.json`).toString();
       manifestList += openTags + manifestUrl + hrefClose + manifestUrl + closeTags;
     }
 
-    const response = '<html><body>' + manifestList + '</body></html>';
+    const response = '<html><body>' + manifestList + '</body></html> \n';
 
     res.writeHead(200, headers);
     res.end(response);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -328,7 +328,7 @@ export default class Marian {
     //     manifestList += openTags + manifestUrl + closeTags;
     //   }
     // }
-    return `<html><body> ${manifestList} </body></html>`;
+    return '<html><body> ${manifestList} </body></html>';
   };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -350,8 +350,10 @@ export default class Marian {
     const otherList = 'start';
     const openTags = '<a href=';
     const closeTags = '></a>';
-    for (let manifest of this.index.manifests) {
-      const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+    for (let i = 0; i < this.index.manifests.length; i++) {
+      const manifestUrl = new URL(
+        `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
+      ).toString();
       manifestList.concat(manifestUrl);
       otherList.concat('Middle');
     }

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -317,19 +317,19 @@ export default class Marian {
   }
 
   private formatManifests = () => {
-    return 'hello again';
+    //   return 'hello again';
+    // };
+    let manifestList = '';
+    const openTags = '<a href=';
+    const closeTags = '></a>';
+    if (this.index.manifests) {
+      for (let manifest of this.index.manifests) {
+        const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+        manifestList += openTags + manifestUrl + closeTags;
+      }
+    }
+    return `<html><body> ${manifestList} </body></html>`;
   };
-  //         let manifestList = '';
-  //     const openTags = '<a href=';
-  //     const closeTags = '></a>';
-  //     if (this.index.manifests) {
-  //       for (let manifest of this.index.manifests) {
-  //         const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-  //         manifestList += openTags + manifestUrl + closeTags;
-  //       }
-  //     }
-  //     return `<html><body> ${manifestList} </body></html>`;
-  // };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -317,19 +317,19 @@ export default class Marian {
   }
 
   private formatManifests = () => {
-    return 'hello thrice';
+    //   return 'hello thrice';
+    // };
+    let manifestList = '';
+    const openTags = '<a href=';
+    const closeTags = '></a>';
+    // if (this.index.manifests) {
+    //   for (let manifest of this.index.manifests) {
+    //     const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
+    //     manifestList += openTags + manifestUrl + closeTags;
+    //   }
+    // }
+    return `<html><body> ${manifestList} </body></html>`;
   };
-  //   let manifestList = '';
-  //   const openTags = '<a href=';
-  //   const closeTags = '></a>';
-  //   if (this.index.manifests) {
-  //     for (let manifest of this.index.manifests) {
-  //       const manifestUrl = new URL(`${this.index.manifestUrlPrefix}/${manifest.searchProperty}.json`).toString();
-  //       manifestList += openTags + manifestUrl + closeTags;
-  //     }
-  //   }
-  //   return `<html><body> ${manifestList} </body></html>`;
-  // };
 
   private async handleManifests(req: http.IncomingMessage, res: http.ServerResponse) {
     const headers = {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -317,7 +317,7 @@ export default class Marian {
   }
 
   //change format of tags so that url is also in each anchor tag
-  private formatManifests = (manifests) => {
+  private formatManifests = (manifests: any) => {
     //   return 'hello thrice';
     // };
     let manifestList = '';

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -356,7 +356,7 @@ export default class Marian {
 
     const response = this.index.manifests.length + '<html><body>' + manifestList + '</body></html>';
     console.log(manifestList);
-    console.log('Hello again');
+    console.log('Hello there');
 
     res.writeHead(200, headers);
     res.end(response);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -346,8 +346,7 @@ export default class Marian {
       return;
     }
 
-    const manifestList = '';
-    let otherList = 'start';
+    let manifestList = '';
     let endList = 'gah';
     const openTags = '<a href=';
     const closeTags = '></a>';
@@ -355,7 +354,7 @@ export default class Marian {
       const manifestUrl = new URL(
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
       ).toString();
-      manifestList.concat(manifestUrl);
+      manifestList += manifestUrl;
       endList = 'end';
     }
 

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -349,16 +349,16 @@ export default class Marian {
     let manifestList = '';
     let endList = 'gah';
     const openTags = '<a href=';
-    const closeTags = '></a>';
+    const hrefClose = '>';
+    const closeTags = '</a>';
     for (let i = 0; i < this.index.manifests.length; i++) {
       const manifestUrl = new URL(
         `${this.index.manifestUrlPrefix}/${this.index.manifests[i].searchProperty}.json`
       ).toString();
-      manifestList += 'hi' + manifestUrl;
-      endList = 'end';
+      manifestList += openTags + manifestUrl + hrefClose + manifestUrl + closeTags;
     }
 
-    const response = this.index.manifests.length + manifestList + endList + '<html><body>' + '</body></html>';
+    const response = endList + '<html><body>' + manifestList + '</body></html>';
     console.log(manifestList);
     console.log('Hello there');
 


### PR DESCRIPTION
### Ticket

[DOP-4593](https://jira.mongodb.org/browse/DOP-4593)
Smartling crawler can't follow links in a JSON array, but it can follow HTML links. This endpoint is only being used for Smartling's crawler so this PR converts the format of all manifest links to HTML

### Notes
Sometimes the 'should properly handle incorrect urls in manifests' test passes and sometimes fails on the same code if I rerun jobs, I am not sure why/if it should be investigated more thoroughly.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
