### PR TITLE
DOP-4593-b hotfix

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -335,7 +335,7 @@ export default class Marian {
     let manifestList = '';
     const openTags = '<div><a href=';
     const hrefClose = '>';
-    const closeTags = '</a></div> \n';
+    const closeTags = '</a><div> \n';
     const urlPrefix = this.index.manifestUrlPrefix;
     for (let manifest of this.index.manifests) {
       const manifestUrl = new URL(`${urlPrefix}/${manifest.searchProperty}.json`).toString();

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -335,7 +335,7 @@ export default class Marian {
     let manifestList = '';
     const openTags = '<div><a href=';
     const hrefClose = '>';
-    const closeTags = '</a><div> \n';
+    const closeTags = '</a></div> \n';
     const urlPrefix = this.index.manifestUrlPrefix;
     for (let manifest of this.index.manifests) {
       const manifestUrl = new URL(`${urlPrefix}/${manifest.searchProperty}.json`).toString();


### PR DESCRIPTION
### Ticket

[DOP-4593](https://jira.mongodb.org/browse/DOP-4593)

### Notes
After [DOP-4593](https://jira.mongodb.org/browse/DOP-4593) was merged, @rayangler caught that we're creating a new div instead of a closing div in the /manifests endpoint [here](https://github.com/mongodb/docs-search-transport/pull/109/files#diff-f709f66121d0b7c81d6292c1b7ed41bbfde1e20b075779bd9fe635162c86e431R338). This PR fixes it.

https://docs-search-transport-dev.docs.staging.corp.mongodb.com/manifests

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
