### PR TITLE
Bump resources for staging and dev instances to 75% of prod

### DIFF
--- a/environments/dev.yml
+++ b/environments/dev.yml
@@ -1,11 +1,11 @@
 ingress:
   enabled: true
   hosts:
-    - docs-search-transport.docs.staging.corp.mongodb.com
+    - docs-search-transport-dev.docs.staging.corp.mongodb.com
 
 env:
   MANIFEST_URI: 's3://docs-search-indexes-test/search-indexes/preprd/'
-  ATLAS_DATABASE: 'search-staging'
+  ATLAS_DATABASE: 'search-test'
   ATLAS_ADMIN_PUB_KEY: 'dgrhrxpv'
   POOL_DB: 'pool_test'
   S3_BUCKET: docs-search-indexes-test

--- a/environments/dev.yml
+++ b/environments/dev.yml
@@ -1,11 +1,11 @@
 ingress:
   enabled: true
   hosts:
-    - docs-search-transport-dev.docs.staging.corp.mongodb.com
+    - docs-search-transport.docs.staging.corp.mongodb.com
 
 env:
   MANIFEST_URI: 's3://docs-search-indexes-test/search-indexes/preprd/'
-  ATLAS_DATABASE: 'search-test'
+  ATLAS_DATABASE: 'search-staging'
   ATLAS_ADMIN_PUB_KEY: 'dgrhrxpv'
   POOL_DB: 'pool_test'
   S3_BUCKET: docs-search-indexes-test
@@ -13,6 +13,6 @@ env:
 
 resources:
   limits:
-    memory: 800Mi
+    memory: 1400Mi
   requests:
-    memory: 600Mi
+    memory: 1200Mi

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -13,6 +13,6 @@ env:
 
 resources:
   limits:
-    memory: 800Mi
+    memory: 1400Mi
   requests:
-    memory: 600Mi
+    memory: 1200Mi


### PR DESCRIPTION
### Notes

Staging and dev instances of Docs Search Transport went offline due to memory limits based on [Splunk logs](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Ddocs-staging%20source%3D*docs-search-transport-dev-web-app-748f6fdcf8-9wbc2*&earliest=1718913259&latest=now&sid=1718916865.28759334&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf). This PR hopes to arbitrarily bump the resources on non-prod instances to 75% of prod instances. 

If this doesn't fix the issue, the backup plan is to bump resources up to match prod's.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
