### PR TITLE
DOP-5081: skip noIndexing branches from being stored into searchPropertyMapping

### DIFF
--- a/src/SearchPropertyMapping/index.ts
+++ b/src/SearchPropertyMapping/index.ts
@@ -29,7 +29,7 @@ const addSearchProperties = (
   branches: Branches[]
 ) => {
   branches.forEach((branch) => {
-    if (!branch.active) {
+    if (!branch.active || branch.noIndexing) {
       return;
     }
 

--- a/src/SearchPropertyMapping/types.ts
+++ b/src/SearchPropertyMapping/types.ts
@@ -9,6 +9,7 @@ export interface Branches {
   versionSelectorLabel: string;
   urlSlug?: string | undefined;
   gitBranchName?: string;
+  noIndexing?: boolean;
 }
 
 export interface Repo {


### PR DESCRIPTION
### Ticket

DOP-5081

### Notes
- This PR skips branches with property for `noIndexing` from being stored into search server's SearchPropertyMapping. This is used when users provide a query term without a project-version filter so that we only serve results from active branches (now updated to `active && !noIndexing`)
- [This function](https://services.cloud.mongodb.com/groups/5bad1d3d96e82129f16c5df3/apps/5d41ef5e2de84772fc7c2de2/functions/6279548c1fdab5262a3460c8) will also have to be updated (used to populate filters on the RHS of search page). I have a draft there that will be deployed at same time of search transport's deploy after the change.



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
