### PR TITLE
(DOP-5566): Respect order in term-result-mappings.ts

### DIFF
--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -111,13 +111,17 @@ export class Query {
     // if we need to boost for matching slug on an exact rawQuery match
     const boostedStrings = strippedMapping[this.rawQuery.trim()];
     if (Array.isArray(boostedStrings) && typeof boostedStrings[0] === 'string') {
-      parts.push({
-        text: {
-          path: 'strippedSlug',
-          query: boostedStrings,
-          score: { boost: { value: 100 } },
-        },
-      });
+      parts.push(
+        ...boostedStrings.map((boostedString, i) => ({
+          text: {
+            path: 'strippedSlug',
+            query: [boostedString],
+            // Boost each entry slightly higher than the next so that entry
+            // order is respected in results
+            score: { boost: { value: 100 + 10 * (boostedStrings.length - i) } },
+          },
+        }))
+      );
     }
 
     parts.push({

--- a/src/data/term-result-mappings.ts
+++ b/src/data/term-result-mappings.ts
@@ -1,3 +1,5 @@
+// Order matters: earlier entries in each array will boost higher than later
+// entries.
 const resultMapping: ResultMapping = {
   and: ['reference/operator/query/and', 'reference/operator/aggregation/and', 'reference/operator/query/all'],
   or: ['reference/operator/query/or', 'reference/operator/aggregation/or', 'reference/operator/query-logical'],

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -51,9 +51,11 @@ describe('Query', () => {
     const nonExistingTermQuery = new Query('constructor').getCompound(null, [], sampleFacetKeys);
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
     const existingTermQuery = new Query('aggregation').getCompound(null, [], sampleFacetKeys);
-    ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
-    ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value as unknown as number) >=
-      100;
+    const queryShould = existingTermQuery.should[0] as NestedCompound;
+    ok(queryShould.compound.must[0].text?.score?.boost !== undefined);
+    ok(queryShould.compound.must[0].text?.score?.boost?.value > 110);
+    // Check for decreasing boost score, which ensures order matters in term result mapping
+    ok(queryShould.compound.must[queryShould.compound.must.length - 1].text?.score?.boost?.value == 100);
   });
 
   it('should have as many clauses as filters passed into the query', () => {

--- a/tests/unit/Query.test.ts
+++ b/tests/unit/Query.test.ts
@@ -52,10 +52,8 @@ describe('Query', () => {
     ok((nonExistingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value === undefined);
     const existingTermQuery = new Query('aggregation').getCompound(null, [], sampleFacetKeys);
     ok((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost !== undefined);
-    ok(
-      ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost
-        ?.value as unknown as number) === 100
-    );
+    ((existingTermQuery.should[0] as NestedCompound).compound.must[0].text?.score?.boost?.value as unknown as number) >=
+      100;
   });
 
   it('should have as many clauses as filters passed into the query', () => {


### PR DESCRIPTION
### Ticket

[DOP-5566](https://jira.mongodb.org/browse/DOP-5566)

### Notes

This gives more boost to earlier entries in the mapped results so as to respect the order given. If every entry is given the same boost, the ordering in result is not deterministic.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
