### PR TITLE
DOP-5316: Only log error if unhandled

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -120,8 +120,7 @@ export default class Marian {
         res.end(err.message);
         return;
       }
-      log.error(`Unhandled error while handling search from URL ${String(parsedUrl)}:`);
-      log.error(String(err));
+      log.error(`Unhandled error while handling search from URL ${String(parsedUrl)}: ${String(err)}`);
       res.writeHead(500, headers);
       res.end();
       return;

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -243,11 +243,11 @@ export default class Marian {
 
     if (!rawQuery) {
       // allow blank query for facet data only
-      throw new InvalidQuery();
+      throw new InvalidQuery('No query found');
     }
 
     if (rawQuery.length > MAXIMUM_QUERY_LENGTH) {
-      throw new InvalidQuery();
+      throw new InvalidQuery(`Query is too long: "${rawQuery}"`);
     }
 
     const filters = extractFacetFilters(parsedUrl.searchParams);
@@ -291,7 +291,7 @@ export default class Marian {
   private async fetchFacetMeta(parsedUrl: URL): Promise<FacetMeta> {
     const rawQuery = (parsedUrl.searchParams.get('q') || '').toString();
     if (!rawQuery || !rawQuery.length) {
-      throw new InvalidQuery();
+      throw new InvalidQuery('No query found');
     }
 
     const filters = extractFacetFilters(parsedUrl.searchParams);

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -114,13 +114,14 @@ export default class Marian {
     try {
       results = await this.fetchResults(parsedUrl);
     } catch (err) {
-      log.error(`Error while handling search from URL ${String(parsedUrl)}:`);
-      log.error(String(err));
       if (err instanceof InvalidQuery) {
         res.writeHead(400, headers);
+        log.warn(err.message);
         res.end(err.message);
         return;
       }
+      log.error(`Unhandled error while handling search from URL ${String(parsedUrl)}:`);
+      log.error(String(err));
       res.writeHead(500, headers);
       res.end();
       return;

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -5,6 +5,7 @@ import { getPropertyMapping } from '../SearchPropertyMapping';
 import { strippedMapping } from '../data/term-result-mappings';
 import { Part, CompoundPart, Compound } from './types';
 
+// InvalidQuery should be an "expected" error in the context of the application
 export class InvalidQuery extends Error {}
 
 function processPart(part: string): string[] {

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -103,7 +103,7 @@ export class Query {
       }
     }
     if (!this.terms.size) {
-      throw new InvalidQuery();
+      throw new InvalidQuery(`No terms found for query: "${queryString}"`);
     }
   }
 


### PR DESCRIPTION
### Ticket

DOP-5316

### Notes

**The problem:**

Splunk is logging too many errors and it's unclear why.

**The solution:**

* Added new error messages to `InvalidQuery` throws to make it more specific **why** a query is not being handled.
* Move the error log that Splunk kept picking up around such that it would only log as an error if it's truly unexpected. We should treat `InvalidQuery` errors as "expected" within the context of the application as we only throw them if the user input is bad. We'll still log a warning in case we need to track and debug them.

We'll see how effective this solution is at reducing Splunk error alerts over time after this is deployed to prod.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
