### PR TITLE
DOP-5578: store user query in collection

### DIFF
--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -112,7 +112,7 @@ export default class Marian {
 
     let results: Document[];
     try {
-      results = await this.fetchResults(parsedUrl);
+      results = await this.fetchResults(parsedUrl, req.headers);
     } catch (err) {
       if (err instanceof InvalidQuery) {
         res.writeHead(400, headers);
@@ -238,7 +238,7 @@ export default class Marian {
     res.end(responseBody);
   }
 
-  private async fetchResults(parsedUrl: URL): Promise<Document[]> {
+  private async fetchResults(parsedUrl: URL, req: http.IncomingHttpHeaders): Promise<Document[]> {
     const rawQuery = (parsedUrl.searchParams.get('q') || '').toString();
 
     if (!rawQuery) {
@@ -258,7 +258,7 @@ export default class Marian {
       searchProperty = [searchProperty];
     }
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    return this.index.search(query, searchProperty, filters, pageNumber);
+    return this.index.search(query, searchProperty, filters, rawQuery, req, pageNumber);
   }
 
   private async fetchTaxonomy(url: string) {

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -238,7 +238,7 @@ export default class Marian {
     res.end(responseBody);
   }
 
-  private async fetchResults(parsedUrl: URL, req: http.IncomingHttpHeaders): Promise<Document[]> {
+  private async fetchResults(parsedUrl: URL, reqHeaders: http.IncomingHttpHeaders): Promise<Document[]> {
     const rawQuery = (parsedUrl.searchParams.get('q') || '').toString();
 
     if (!rawQuery) {
@@ -258,7 +258,7 @@ export default class Marian {
       searchProperty = [searchProperty];
     }
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    return this.index.search(query, searchProperty, filters, rawQuery, req, pageNumber);
+    return this.index.search(query, searchProperty, filters, rawQuery, reqHeaders, pageNumber);
   }
 
   private async fetchTaxonomy(url: string) {

--- a/src/Query/types.ts
+++ b/src/Query/types.ts
@@ -55,3 +55,8 @@ export type Compound = {
   must: Must[];
   minimumShouldMatch: number;
 };
+
+export interface QueryDocument extends Document {
+  searchTerm: string;
+  userAgent?: string;
+}

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -146,11 +146,14 @@ export class SearchIndex {
 
   async saveUserQuery(parsedQuery: string, reqHeaders: IncomingHttpHeaders): Promise<void> {
     // avoiding await to allow update in background
-    console.log('saveuserquery');
-    this.userQueryCollection.insertOne({
-      searchTerm: parsedQuery,
-      userAgent: reqHeaders['user-agent'],
-    });
+    this.userQueryCollection
+      .insertOne({
+        searchTerm: parsedQuery,
+        userAgent: reqHeaders['user-agent'],
+      })
+      .catch((err) => {
+        log.error(err);
+      });
   }
 
   private async sync(manifests: Manifest[]): Promise<RefreshInfo> {

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -21,7 +21,7 @@ describe('Searching', function () {
   const client = new MongoClient(connectionString);
   let index: SearchIndex;
 
-  this.beforeAll('Loading test data', async function (done) {
+  this.beforeAll('Loading test data', async function () {
     try {
       await client.connect();
       index = new SearchIndex(
@@ -39,13 +39,9 @@ describe('Searching', function () {
       await index.createRecommendedIndexes();
       console.log('created recommended indexes');
       console.log(result);
-      // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃
-      // if (result && (result.deleted || result.updated.length > 0)) {
-      //   this.timeout(30000);
-      //   return new Promise((resolve) => setTimeout(resolve, 10000));
-      // }
-      done();
-      // return new Promise((resolve) => setTimeout(done, 10000));
+      // search indexes may take time to reflect
+      // check cloud for search index progress
+      return;
     } catch (e) {
       console.error(e);
     }

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -40,10 +40,10 @@ describe('Searching', function () {
       console.log('created recommended indexes');
       console.log(result);
       // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃
-      if (result && (result.deleted || result.updated.length > 0)) {
-        this.timeout(30000);
-        return new Promise((resolve) => setTimeout(resolve, 10000));
-      }
+      // if (result && (result.deleted || result.updated.length > 0)) {
+      //   this.timeout(30000);
+      //   return new Promise((resolve) => setTimeout(resolve, 10000));
+      // }
       return new Promise((resolve) => setTimeout(resolve, 10000));
     } catch (e) {
       console.error(e);

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -21,7 +21,7 @@ describe('Searching', function () {
   const client = new MongoClient(connectionString);
   let index: SearchIndex;
 
-  this.beforeAll('Loading test data', async function () {
+  before('Loading test data', async function () {
     try {
       await client.connect();
       index = new SearchIndex(

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -40,10 +40,10 @@ describe('Searching', function () {
       console.log('created recommended indexes');
       console.log(result);
       // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃
-      console.log(result);
       if (result && (result.deleted || result.updated.length > 0)) {
+        this.timeout(30000);
+        return new Promise((resolve) => setTimeout(resolve, 10000));
       }
-      this.timeout(30000);
       return new Promise((resolve) => setTimeout(resolve, 10000));
     } catch (e) {
       console.error(e);

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -36,12 +36,9 @@ describe('Searching', function () {
       // fail due to empty facet text match
       index.facetKeys = sampleFacetKeys;
       console.log('index loaded');
-      await index.createRecommendedIndexes();
-      console.log('created recommended indexes');
-      console.log(result);
       // search indexes may take time to reflect
       // check cloud for search index progress
-      return;
+      return index.createRecommendedIndexes();
     } catch (e) {
       console.error(e);
     }

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -44,11 +44,8 @@ describe('Searching', function () {
       //   this.timeout(30000);
       //   return new Promise((resolve) => setTimeout(resolve, 10000));
       // }
-      setTimeout(() => {
-        done();
-        return Promise.resolve();
-      }, 10000);
-      // return new Promise((resolve) => setTimeout(resolve, 10000));
+      done();
+      // return new Promise((resolve) => setTimeout(done, 10000));
     } catch (e) {
       console.error(e);
     }

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -21,7 +21,7 @@ describe('Searching', function () {
   const client = new MongoClient(connectionString);
   let index: SearchIndex;
 
-  this.beforeAll('Loading test data', async function () {
+  this.beforeAll('Loading test data', async function (done) {
     try {
       await client.connect();
       index = new SearchIndex(
@@ -44,7 +44,11 @@ describe('Searching', function () {
       //   this.timeout(30000);
       //   return new Promise((resolve) => setTimeout(resolve, 10000));
       // }
-      return new Promise((resolve) => setTimeout(resolve, 10000));
+      setTimeout(() => {
+        done();
+        return Promise.resolve();
+      }, 10000);
+      // return new Promise((resolve) => setTimeout(resolve, 10000));
     } catch (e) {
       console.error(e);
     }

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -40,10 +40,11 @@ describe('Searching', function () {
       console.log('created recommended indexes');
       console.log(result);
       // I don't see a way to wait for indexing to complete, so... just sleep for some unscientific amount of time 🙃
+      console.log(result);
       if (result && (result.deleted || result.updated.length > 0)) {
-        this.timeout(30000);
-        return new Promise((resolve) => setTimeout(resolve, 10000));
       }
+      this.timeout(30000);
+      return new Promise((resolve) => setTimeout(resolve, 10000));
     } catch (e) {
       console.error(e);
     }
@@ -51,7 +52,7 @@ describe('Searching', function () {
 
   // Test variants of searchProperty
   it('should properly handle incorrect urls in manifests', async () => {
-    let result = await index.search(new Query('manual'), ['manual-v5.1'], []);
+    let result = await index.search(new Query('manual'), ['manual-v5.1'], [], 'manual', {});
     strictEqual(result[0]?.url, 'https://docs.mongodb.com/v5.1/index.html');
   });
 


### PR DESCRIPTION
### Ticket

DOP-5578
This PR aims to store searched terms into a MDB collection in the search db.

### Notes
- Tested this locally and was able to save to `search-test` DB under collection `query`

![image](https://github.com/user-attachments/assets/62fe6839-51d2-4853-9437-85d92f0b6c93)

**Note:** unrelated test failing for the Search Index test. Possibly worth rewriting the test suite so we can operate on one set of data



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
