### PR TITLE
DOP-5912: Add `resultsFound` & `appliedFilter` booleans to db insertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4402,7 +4402,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.1.0",

--- a/src/Marian/index.ts
+++ b/src/Marian/index.ts
@@ -250,7 +250,6 @@ export default class Marian {
       throw new InvalidQuery(`Query is too long: "${rawQuery}"`);
     }
 
-    const filters = extractFacetFilters(parsedUrl.searchParams);
     const query = new Query(rawQuery);
 
     let searchProperty = parsedUrl.searchParams.getAll('searchProperty') || null;
@@ -258,7 +257,7 @@ export default class Marian {
       searchProperty = [searchProperty];
     }
     const pageNumber = Number(parsedUrl.searchParams.get('page'));
-    return this.index.search(query, searchProperty, filters, rawQuery, reqHeaders, pageNumber);
+    return this.index.search(query, searchProperty, parsedUrl.searchParams, rawQuery, reqHeaders, pageNumber);
   }
 
   private async fetchTaxonomy(url: string) {

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -85,13 +85,6 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return Object.values(queryParamLists);
 };
 
-export const getFacetsString = (params: URLSearchParams): string => {
-  return Array.from(params.entries())
-    .filter(([key]) => key.startsWith('facets.'))
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-};
-
 export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
   const facetKeysForAgg: FacetAggregationStage = {};
 

--- a/src/Query/util.ts
+++ b/src/Query/util.ts
@@ -85,6 +85,13 @@ export const extractFacetFilters = (searchParams: URL['searchParams']): Filter<D
   return Object.values(queryParamLists);
 };
 
+export const getFacetsString = (params: URLSearchParams): string => {
+  return Array.from(params.entries())
+    .filter(([key]) => key.startsWith('facets.'))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+};
+
 export const getFacetAggregationStages = (taxonomy: FacetOption[]) => {
   const facetKeysForAgg: FacetAggregationStage = {};
 

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -26,7 +26,7 @@ import {
 
 import { getFacetKeys } from '../AtlasAdmin/utils';
 import { QueryDocument } from '../Query/types';
-import { extractFacetFilters, getFacetsString } from '../Query/util';
+import { extractFacetFilters } from '../Query/util';
 
 const log = new Logger({
   showTimestamp: true,
@@ -159,7 +159,7 @@ export class SearchIndex {
         searchTerm: parsedQuery,
         userAgent: reqHeaders['user-agent'],
         resultsFound: numResults,
-        filters: getFacetsString(searchParams),
+        filters: searchParams.get('searchProperty'),
       })
       .catch((err) => {
         log.error(err);

--- a/src/SearchIndex/index.ts
+++ b/src/SearchIndex/index.ts
@@ -145,7 +145,12 @@ export class SearchIndex {
     ]);
   }
 
-  async saveUserQuery(parsedQuery: string, reqHeaders: IncomingHttpHeaders, numResults: number, filters: Filter<Document>[]): Promise<void> {
+  async saveUserQuery(
+    parsedQuery: string,
+    reqHeaders: IncomingHttpHeaders,
+    numResults: number,
+    filters: Filter<Document>[]
+  ): Promise<void> {
     const userAppliedFilters = Object.entries(filters).length > 0;
 
     // avoiding await to allow update in background

--- a/src/data/term-result-mappings.ts
+++ b/src/data/term-result-mappings.ts
@@ -102,9 +102,21 @@ const resultMapping: ResultMapping = {
     'reference/sql-aggregation-comparison',
   ],
   operator: ['reference/operator/query', 'reference/operator/update', 'reference/operator/aggregation-pipeline'],
-  exists: ['reference/operator/query/exists', 'atlas/atlas-search/exists', 'drivers/node/current/crud/query/query-document/'],
-  $exists: ['reference/operator/query/exists', 'atlas/atlas-search/exists', 'drivers/node/current/crud/query/query-document/'],
-  exist: ['reference/operator/query/exists', 'atlas/atlas-search/exists', 'drivers/node/current/crud/query/query-document/'],
+  exists: [
+    'reference/operator/query/exists',
+    'atlas/atlas-search/exists',
+    'drivers/node/current/crud/query/query-document/',
+  ],
+  $exists: [
+    'reference/operator/query/exists',
+    'atlas/atlas-search/exists',
+    'drivers/node/current/crud/query/query-document/',
+  ],
+  exist: [
+    'reference/operator/query/exists',
+    'atlas/atlas-search/exists',
+    'drivers/node/current/crud/query/query-document/',
+  ],
   mongoclient: [
     'drivers/kotlin/coroutine/current/fundamentals/connection/mongoclientsettings',
     'drivers/java/sync/current/connection/mongoclient',
@@ -151,10 +163,7 @@ const resultMapping: ResultMapping = {
   $regex: ['reference/operator/query/regex', 'atlas/atlas-search/regex', 'reference/operator/aggregation/regexMatch'],
   $eq: ['reference/operator/query/eq', 'reference/operator/aggregation/eq', 'reference/operator/query/elemMatch'],
   $size: ['reference/operator/query/size', 'reference/operator/aggregation/size', 'tutorial/query-arrays'],
-  $sort: [
-    'reference/operator/update/sort',
-    'reference/operator/aggregation/sort',
-  ],
+  $sort: ['reference/operator/update/sort', 'reference/operator/aggregation/sort'],
   $inc: [
     'reference/operator/update/inc',
     'reference/method/db.collection.updateMany',
@@ -178,10 +187,7 @@ const resultMapping: ResultMapping = {
     'tutorial/update-documents-with-aggregation-pipeline',
     'reference/operator/aggregation/sum',
   ],
-  $first: [
-    'reference/operator/aggregation/first',
-    'reference/operator/aggregation/firstN',
-  ],
+  $first: ['reference/operator/aggregation/first', 'reference/operator/aggregation/firstN'],
   $count: ['reference/operator/aggregation/count', 'reference/command/count', 'atlas/atlas-search/counting'],
   indexes: ['indexes'],
   $addFields: [

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -51,7 +51,7 @@ describe('Searching', function () {
 
   // Test variants of searchProperty
   it('should properly handle incorrect urls in manifests', async () => {
-    let result = await index.search(new Query('manual'), ['manual-v5.1'], [], 'manual', {});
+    let result = await index.search(new Query('manual'), ['manual-v5.1'], new URLSearchParams(), 'manual', {});
     strictEqual(result[0]?.url, 'https://docs.mongodb.com/v5.1/index.html');
   });
   this.afterAll(async function () {


### PR DESCRIPTION
### Ticket

DOP-5912

### Notes

Per Sarah Lin's request, we'll add simple booleans to our search.query collection to help with query analytics.

`resultsFound` will be true if at least one result was returned to the user.
`appliedFilter` will be true if the user applied any filters to their search query.

This PR along with the creation of a script [in this PR](https://github.com/10gen/snooty-scripts/pull/36) will satisfy the entirety of DOP-5912 and give Sarah Lin the analytics she needs going forward.

To test: you can use staging. 

Staging link: 
https://docs-search-transport-dev.docs.staging.corp.mongodb.com/search/

This now creates the specified documents in the `search-staging.query` db collection

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
